### PR TITLE
Make @actions/core accessible to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ be provided:
   [octokit/rest.js](https://github.com/octokit/rest.js) client
 - `context` An object containing the [context of the workflow
   run](https://github.com/actions/toolkit/tree/master/packages/github)
+- `core` Functions for inputs, outputs, results, logging, secrets and variables from [@actions/core](https://github.com/actions/toolkit/blob/master/packages/core)
 
 Since the `script` is just a function body, these values will already be
 defined, so you don't have to (see examples below).

--- a/main.js
+++ b/main.js
@@ -16,8 +16,8 @@ async function main() {
   if (previews != null) opts.previews = previews.split(',')
   const client = new GitHub(token, opts)
   const script = core.getInput('script', {required: true})
-  const fn = new AsyncFunction('github', 'context', script)
-  const result = await fn(client, context)
+  const fn = new AsyncFunction('github', 'context', 'core', script)
+  const result = await fn(client, context, core)
   core.setOutput('result', JSON.stringify(result))
 }
 


### PR DESCRIPTION
This may very well be out of scope of your project, so feel free to close this without giving it any further attention.

The code in this PR makes the already present dependency [@actions/core](https://github.com/actions/toolkit/blob/master/packages/core) available to scripts using this action.

## Our challenge

The issue number of a closed and merged PR is not available for merged PRs in the `pull_request` + `closed` event. In other PR events we would take that from `GITHUB_REF`, but for merged PRs, this is set to `master` instead of `refs/pull/:prNumber/merge`.* So we decided to use this action to retrieve the issue number from the `context`.

## Our solution in this PR

Getting the issue number from the context was easy enough, but now we had no means to make it available to subsequent actions. Since `@actions/core` was already a dependency, we made it available in the script, so we can use `core.exportVariable` to pass along the retrieved data and make it available as an env var to subsequent actions.

_* I guess that is to be expected, but it seems to go against what is documented [here](https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-event-pull_request)._