### PR TITLE
Fix example context properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.issues.addLabels({
-              issue_number: context.issue,
-              owner: context.owner,
-              repo: context.repo,
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               labels: ['Triage']
             })
 ```
@@ -101,9 +101,9 @@ jobs:
             }
 
             await github.issues.createComment({
-              issue_number: context.issue,
-              owner: context.owner,
-              repo: context.repo,
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               body: 'Welcome, new contributor!'
             })
 ```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.issues.createComment({
-              issue_number: context.payload.issue.number,
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               body: '👋 Thanks for reporting!'
             })
 ```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.issues.createComment({
-              issue_number: context.issue,
-              owner: context.owner,
-              repo: context.repo,
+              issue_number: context.payload.issue.number,
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
               body: '👋 Thanks for reporting!'
             })
 ```


### PR DESCRIPTION
The example action wasn't working when using `context.issue`, `context.owner` and `context.repo`. This PR changes it to use `context.issue.number`, `context.repo.owner` and `context.repo.repo`, which seems to fix it.