### PR TITLE
Default to the GitHub token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,8 @@ inputs:
     required: true
   github-token:
     description: The GitHub token used to create an authenticated client
-    required: true
+    default: ${{ github.token }}
+    required: false
   debug:
     description: Whether to tell the GitHub client to log details of its requests
     default: false


### PR DESCRIPTION
### Change
With the system side changes to support `actions/checkout@v2`, some of the `github` context can now be used in the action.yml file as defaults, including the GitHub token.

This removes the need for the user to specify the GitHub token as input for *most* cases.

### Verification:

[Workflow](https://github.com/joshmgross/github-script-testing/blob/master/.github/workflows/%F0%9F%91%8B.yml)
[Sample Issue](https://github.com/joshmgross/github-script-testing/issues/2)


Let me know if you want me to update the examples in the README.md, it might be worth having at least one example using a token.