### PR TITLE
fix: Example YAML schema to match Actions Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ By default, github-script will use the token provided to your workflow.
 
 ```yaml
 on:
-  issues: {types: opened}
+  issues:
+    types: [opened]
 
 jobs:
   comment:
@@ -59,7 +60,8 @@ jobs:
 
 ```yaml
 on:
-  issues: {types: opened}
+  issues:
+    types: [opened]
 
 jobs:
   apply-label:


### PR DESCRIPTION
Both ways should be valid, but the regular nested YAML keys seems to be the format of the regular GitHub Actions docs