### PR TITLE
Fix Action references in separate file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ jobs:
   echo-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: @actions/checkout@v2
-      - uses: @actions/github-script@v1
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@v1
         with:
           script: |
             const path = require('path')


### PR DESCRIPTION
These references shouldn't use the `@actions` syntax, which is for the npm `@actions` packages.

cc @jclem 