### PR TITLE
Adds note that absolute path is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ jobs:
             const scriptPath = path.resolve('./path/to/script.js')
             console.log(require(scriptPath)({context}))
 ```
+_(Note that the script path given to `require()` must be an absolute path in this case.)_
 
 And then export a function from your module:
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ jobs:
             const scriptPath = path.resolve('./path/to/script.js')
             console.log(require(scriptPath)({context}))
 ```
-_(Note that the script path given to `require()` must be an absolute path in this case.)_
+
+*(Note that the script path given to `require()` must be an absolute path in this case, hence the call to `path.resolve()`.)*
 
 And then export a function from your module:
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ jobs:
             console.log(require(scriptPath)({context}))
 ```
 
-*(Note that the script path given to `require()` must be an absolute path in this case, hence the call to `path.resolve()`.)*
+*Note that the script path given to `require()` must be an absolute path in this case, hence the call to `path.resolve()`.*
 
 And then export a function from your module:
 


### PR DESCRIPTION
An absolute path is required when calling `require()` from within the github-script's script in the workflow YAML.

This PR adds a note for this in the ["Run a separate file"](https://github.com/actions/github-script#run-a-separate-file) section of the readme.