### PR TITLE
docs: use GITHUB_WORKSPACE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ jobs:
       - uses: actions/github-script@v2
         with:
           script: |
-            const script = require(`${process.env.GITHUB_WORKSPACE}/.path/to/script.js`)
-            console.log(script(github, context))
+            const script = require(`${process.env.GITHUB_WORKSPACE}/path/to/script.js`)
+            console.log(script({github, context}))
 ```
 
-*Note that the script path given to `require()` must be an **absolute path** in this case, hence using [`GITHUB_WORKSPACE`](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)*
+*Note that the script path given to `require()` must be an **absolute path** in this case, hence using [`GITHUB_WORKSPACE`](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).*
 
 And then export a function from your module:
 

--- a/README.md
+++ b/README.md
@@ -198,17 +198,16 @@ jobs:
       - uses: actions/github-script@v2
         with:
           script: |
-            const path = require('path')
-            const scriptPath = path.resolve('./path/to/script.js')
-            console.log(require(scriptPath)({context}))
+            const script = require(`${process.env.GITHUB_WORKSPACE}/.path/to/script.js`)
+            console.log(script(github, context))
 ```
 
-*Note that the script path given to `require()` must be an absolute path in this case, hence the call to `path.resolve()`.*
+*Note that the script path given to `require()` must be an **absolute path** in this case, hence using [`GITHUB_WORKSPACE`](https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables)*
 
 And then export a function from your module:
 
 ```javascript
-module.exports = ({context}) => {
+module.exports = (github, context) => {
   return context.payload.client_payload.value
 }
 ```


### PR DESCRIPTION
- update example for using `GITHUB_WORKSPACE` environment variable to keep things simple, and use less steps
- include `github` object as a parameter to the sample script to better illustrate usage