### PR TITLE
chore: expose `module` to userscript

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
 
   // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
   const result = await callAsyncFunction(
-    {require: require, github, context, core, io},
+    {require: require, module: module, github, context, core, io},
     script
   )
 


### PR DESCRIPTION
`module` is required when we want to use `esm` in user script

https://github.com/standard-things/esm#getting-started 