### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ See [development.md](/docs/development.md).
 
 ## Reading step results
 
+Print the available attributes of context:
+
+```yaml
+- name: View context attributes
+  uses: actions/github-script@0.9.0
+  with:
+    script: console.log(context)
+``` 
+
 The return value of the script will be in the step's outputs under the
 "result" key.
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,6 @@ See [development.md](/docs/development.md).
 
 ## Reading step results
 
-Print the available attributes of context:
-
-```yaml
-- name: View context attributes
-  uses: actions/github-script@0.9.0
-  with:
-    script: console.log(context)
-``` 
-
 The return value of the script will be in the step's outputs under the
 "result" key.
 
@@ -79,6 +70,15 @@ Note that `github-token` is optional in this action, and the input is there
 in case you need to use a non-default token.
 
 By default, github-script will use the token provided to your workflow.
+
+### Print the available attributes of context:
+
+```yaml
+- name: View context attributes
+  uses: actions/github-script@0.9.0
+  with:
+    script: console.log(context)
+``` 
 
 ### Comment on an issue
 


### PR DESCRIPTION
I spent longer than I care to admit yesterday trying to track down documentation on what was available in the object context other than what was shown in examples but could never correlate it directly to the github context listed in the [contexts doc](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions) nor the octokit documentation.  Just knowing that you could simply print out object values may save a future newbie time