### PR TITLE
Use @v3 in 'View context attributes' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ By default, github-script will use the token provided to your workflow.
 
 ```yaml
 - name: View context attributes
-  uses: actions/github-script@0.9.0
+  uses: actions/github-script@v3
   with:
     script: console.log(context)
 ``` 


### PR DESCRIPTION
This makes the version of github-script used in the 'View context attributes' example consistent with the version used by all of the other examples in the README.