### PR TITLE
Fix typo from #117

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -20,6 +20,10 @@ jobs:
               issue_number: context.payload.number,
             })
 
+            // Find any comment already made by the bot.                                                                                                    
+            const botComment = comments.find(comment => comment.user.id === 41898282)                                                                       
+            const commentBody = "Hello from actions/github-script! (${{ github.sha }})"                  
+
             if (context.payload.pull_request.head.repo.full_name !== 'actions/github-script') {
               console.log('Not attempting to write comment on PR from fork');
             } else {


### PR DESCRIPTION
I accidentally removed two lines I did not intend to. This would only
break for PRs opened on the repo directly.