### PR TITLE
Link to better octokit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ input should be the body of an asynchronous function call. The following
 arguments will be provided:
 
 - `github` A pre-authenticated
-  [octokit/rest.js](https://octokit.github.io/rest.js/v18) client with pagination plugins
+  [octokit/rest.js](https://octokit.github.io/rest.js) client with pagination plugins
 - `context` An object containing the [context of the workflow
   run](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts)
 - `core` A reference to the [@actions/core](https://github.com/actions/toolkit/tree/main/packages/core) package

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ input should be the body of an asynchronous function call. The following
 arguments will be provided:
 
 - `github` A pre-authenticated
-  [octokit/core.js](https://github.com/octokit/core.js#readme) client with REST endpoints and pagination plugins
+  [octokit/rest.js](https://octokit.github.io/rest.js/v18) client with pagination plugins
 - `context` An object containing the [context of the workflow
   run](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts)
 - `core` A reference to the [@actions/core](https://github.com/actions/toolkit/tree/main/packages/core) package


### PR DESCRIPTION
Hi there, thanks for this project!

It seems like the `octokit/rest.js` documentation would be better to link to here, since it shows the methods that are used in the readme.