### PR TITLE
Document how to use npm packages and env input

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ jobs:
           node-version: 14
       - run: npm ci
       # or one-off:
-      - run: npm install -g execa
+      - run: npm install execa
       - uses: actions/github-script@v3
         with:
           script: |

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ in case you need to use a non-default token.
 
 By default, github-script will use the token provided to your workflow.
 
-### Print the available attributes of context:
+### Print the available attributes of context
 
 ```yaml
 - name: View context attributes
   uses: actions/github-script@v3
   with:
     script: console.log(context)
-``` 
+```
 
 ### Comment on an issue
 
@@ -200,7 +200,6 @@ contain the actual diff text.
 You can use the `github.graphql` object to run custom GraphQL queries against the GitHub API.
 
 ```yaml
-
 jobs:
   list-issues:
     runs-on: ubuntu-latest
@@ -225,7 +224,6 @@ jobs:
             }
             const result = await github.graphql(query, variables)
             console.log(result)
-
 ```
 
 ### Run a separate file
@@ -268,3 +266,31 @@ external function.
 Additionally, you'll want to use the [checkout
 action](https://github.com/actions/checkout) to make sure your script file is
 available.
+
+### Use npm packages
+
+Like importing your own files above, you can also use installed modules:
+
+```yaml
+on: push
+
+jobs:
+  echo-input:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm ci
+      # or one-off:
+      - run: npm install -g execa
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            const execa = require(`${process.env.GITHUB_WORKSPACE}/node_modules/execa`)
+
+            const { stdout } = await execa('echo', ['hello', 'world'])
+
+            console.log(stdout)
+```

--- a/README.md
+++ b/README.md
@@ -294,3 +294,25 @@ jobs:
 
             console.log(stdout)
 ```
+
+### Use env as input
+
+You can set env vars to use them in your script:
+
+```yaml
+on: push
+
+jobs:
+  echo-input:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        env:
+          FIRST_NAME: Mona
+          LAST_NAME: Octocat
+        with:
+          script: |
+            const { FIRST_NAME, LAST_NAME } = process.env
+
+            console.log(`Hello ${FIRST_NAME} ${LAST_NAME}`)
+```


### PR DESCRIPTION
ℹ️  Updated to document `env` and `process.env` as inputs. 

---

We've been using `actions/github-script` to glue together different build tools. We've had cases where we want to passthrough outputs of other scripts to this action –

- One way would be to just use an input value:

  ```yaml
  - uses: actions/github-script@v3
    with:
      foo: 'bar'
      script: console.log(core.getInput('foo'))
  ```

  which works, but displays this warning:

  ```
  Warning: Unexpected input(s) 'foo', valid inputs are ['script', 'github-token', 'debug', 'user-agent', 'previews', 'result-encoding']
  ```

- Another way would be to inline the value:

  ```yaml
  - uses: actions/github-script@v3
    with:
      script: console.log('${{ 'foo' }}')
  ```

  but this can cause issues depending on what the value of the string is, and requires you to be aware of how your string will interact with the program:

  ```yaml
  - uses: actions/github-script@v3
    with:
      script: console.log('${{ 'Single quotes can kill: '' a script' }}')

  # SyntaxError: missing ) after argument list
  ```

---

So this PR introduces a simple `input` variable that is exposed directly to the function:

```yaml
- uses: actions/github-script@v3
  with:
    input: hello world
    script: console.log(input)
```

It can be combined with `JSON.parse(input)` in the script to pass through stringified JSON (from other jobs or CLI tools, for example).

---

I also made two other changes

- Changed the PR comment workflow to check whether the base and head repos are the same, so that changes can be tested more easily on forks (for example, checking my changes here: nihalgonsalves/github-script#1). It still won't comment on PRs _across_ forks (like this one).
- In addition to the docs for this input variable, I also added a README section documenting how installed packages can be used.
