### PR TITLE
Use non-Webpack-require in evaluated scripts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6144,7 +6144,7 @@ async function main() {
     const github = Object(lib_github.getOctokit)(token, opts);
     const script = Object(core.getInput)('script', { required: true });
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
-    const result = await callAsyncFunction({ require: __webpack_require__(875), github, context: lib_github.context, core: core, glob: glob, io: io }, script);
+    const result = await callAsyncFunction({ require: require, github, context: lib_github.context, core: core, glob: glob, io: io }, script);
     let encoding = Object(core.getInput)('result-encoding');
     encoding = encoding ? encoding : 'json';
     let output;
@@ -6900,25 +6900,6 @@ function expand(str, isTop) {
 }
 
 
-
-/***/ }),
-
-/***/ 875:
-/***/ (function(module) {
-
-function webpackEmptyContext(req) {
-	if (typeof req === 'number' && __webpack_require__.m[req])
-  return __webpack_require__(req);
-try { return require(req) }
-catch (e) { if (e.code !== 'MODULE_NOT_FOUND') throw e }
-var e = new Error("Cannot find module '" + req + "'");
-	e.code = 'MODULE_NOT_FOUND';
-	throw e;
-}
-webpackEmptyContext.keys = function() { return []; };
-webpackEmptyContext.resolve = webpackEmptyContext;
-module.exports = webpackEmptyContext;
-webpackEmptyContext.id = 875;
 
 /***/ }),
 

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import {Context} from '@actions/github/lib/context'
-import {GitHub} from '@actions/github/lib/utils'
+import { Context } from '@actions/github/lib/context'
+import { GitHub } from '@actions/github/lib/utils'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 import {callAsyncFunction} from './async-function'
 
+declare const __non_webpack_require__: typeof require
+
 process.on('unhandledRejection', handleError)
 main().catch(handleError)
 
@@ -29,7 +31,7 @@ async function main(): Promise<void> {
 
   // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
   const result = await callAsyncFunction(
-    {require: require, github, context, core, glob, io},
+    {require: __non_webpack_require__, github, context, core, glob, io},
     script
   )
 


### PR DESCRIPTION
Although it probably has no impact on users, we are currently passing the Webpack form of require to the scripts we run. This uses the `__non_webpack_require__` const that Webpack provides and declares a const to make TypeScript happy.