### PR TITLE
Support installed npm modules and relative require

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ jobs:
   test-return:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - id: output-set
         uses: ./
         with:
@@ -22,6 +23,7 @@ jobs:
   test-relative-require:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - id: output-set
         uses: ./
         with:
@@ -36,6 +38,7 @@ jobs:
   test-npm-require:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - id: output-set
         uses: ./
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   push: {branches: main}
 
 jobs:
-  integration:
+  test-return:
     runs-on: ubuntu-latest
     steps:
       - id: output-set
@@ -15,5 +15,33 @@ jobs:
           input-value: output
       - run: |
           if [[ "${{steps.output-set.outputs.result}}" != "output" ]]; then
+            exit 1
+          fi
+
+  test-relative-require:
+    runs-on: ubuntu-latest
+    steps:
+      - id: output-set
+        uses: actions/github-script@main
+        with:
+          script: return require('./package.json').name
+          result-encoding: string
+          input-value: output
+      - run: |
+          if [[ "${{steps.output-set.outputs.result}}" != "github-script" ]]; then
+            exit 1
+          fi
+
+  test-npm-require:
+    runs-on: ubuntu-latest
+    steps:
+      - id: output-set
+        uses: actions/github-script@main
+        with:
+          script: return require('@actions/core/package.json').name
+          result-encoding: string
+          input-value: output
+      - run: |
+          if [[ "${{steps.output-set.outputs.result}}" != "@actions/core" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,13 +2,14 @@ name: Integration
 
 on:
   push: {branches: main}
+  pull_request: {branches: main}
 
 jobs:
   test-return:
     runs-on: ubuntu-latest
     steps:
       - id: output-set
-        uses: actions/github-script@main
+        uses: ./
         with:
           script: return core.getInput('input-value')
           result-encoding: string
@@ -22,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: output-set
-        uses: actions/github-script@main
+        uses: ./
         with:
           script: return require('./package.json').name
           result-encoding: string
@@ -36,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: output-set
-        uses: actions/github-script@main
+        uses: ./
         with:
           script: return require('@actions/core/package.json').name
           result-encoding: string

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
           path: ~/.npm
           key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}
           restore-keys: ${{runner.os}}-npm-
-      - uses: npm ci
+      - run: npm ci
       - id: output-set
         uses: ./
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}
+          restore-keys: ${{runner.os}}-npm-
+      - uses: npm ci
       - id: output-set
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -18,18 +18,12 @@ arguments will be provided:
 - `core` A reference to the [@actions/core](https://github.com/actions/toolkit/tree/main/packages/core) package
 - `glob` A reference to the [@actions/glob](https://github.com/actions/toolkit/tree/main/packages/glob) package
 - `io` A reference to the [@actions/io](https://github.com/actions/toolkit/tree/main/packages/io) package
-- `require` Is available, with some caveats:
-  - The location of the module that runs this action is where the Actions
-    runner downloads the github-script action to, so the `require` passed to
-    your script is actually a proxy that intercepts calls to require relative
-    paths and transforms them into an absolute path in the working directory,
-    instead.
-  - If you want to require an npm module in your working directory, you still
-    need to specify the relative path, including `node_modules`, such as
-    `./node_modules/lodash`.
-  - If for some reason you need the non-wrapped `require`, there is an escape
-    hatch available: `__original_require__` is the original value of `require`
-    without our wrapping applied.
+- `require` A proxy wrapper around the normal Node.js `require` to enable
+  requiring relative paths (relative to the current working directory) and
+  requiring npm packages installed in the current working directory. If for
+  some reason you need the non-wrapped `require`, there is an escape hatch
+  available: `__original_require__` is the original value of `require` without
+  our wrapping applied.
 
 Since the `script` is just a function body, these values will already be
 defined, so you don't have to (see examples below).
@@ -255,7 +249,7 @@ jobs:
       - uses: actions/github-script@v3
         with:
           script: |
-            const script = require(`./path/to/script.js`)
+            const script = require('./path/to/script.js')
             console.log(script({github, context}))
 ```
 
@@ -295,7 +289,7 @@ jobs:
           SHA: '${{env.parentSHA}}'
         with:
           script: |
-            const script = require(`./path/to/script.js`)
+            const script = require('./path/to/script.js')
             await script({github, context, core})
 ```
 
@@ -334,17 +328,12 @@ jobs:
       - uses: actions/github-script@v3
         with:
           script: |
-            const execa = require(`./node_modules/execa`)
+            const execa = require('execa')
 
             const { stdout } = await execa('echo', ['hello', 'world'])
 
             console.log(stdout)
 ```
-
-_(Note that at this time, one still has to specify `node_modules` in the
-require path for modules in the working directory of the step that is
-running. Hopefully we will have a solution for this in the future, but not
-quite, yet.)_
 
 ### Use env as input
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The return value of the script will be in the step's outputs under the
 "result" key.
 
 ```yaml
-- uses: actions/github-script@v3
+- uses: actions/github-script@v4
   id: set-result
   with:
     script: return "Hello!"
@@ -63,7 +63,7 @@ output of a github-script step. For some workflows, string encoding is preferred
 `result-encoding` input:
 
 ```yaml
-- uses: actions/github-script@v3
+- uses: actions/github-script@v4
   id: my-script
   with:
     github-token: ${{secrets.GITHUB_TOKEN}}
@@ -82,7 +82,7 @@ By default, github-script will use the token provided to your workflow.
 
 ```yaml
 - name: View context attributes
-  uses: actions/github-script@v3
+  uses: actions/github-script@v4
   with:
     script: console.log(context)
 ```
@@ -98,7 +98,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -121,7 +121,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -142,7 +142,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -186,7 +186,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -211,7 +211,7 @@ jobs:
   list-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           script: |
             const script = require('./path/to/script.js')
@@ -284,7 +284,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         env:
           SHA: '${{env.parentSHA}}'
         with:
@@ -325,7 +325,7 @@ jobs:
       - run: npm ci
       # or one-off:
       - run: npm install execa
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         with:
           script: |
             const execa = require('execa')
@@ -346,7 +346,7 @@ jobs:
   echo-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4
         env:
           FIRST_NAME: Mona
           LAST_NAME: Octocat

--- a/dist/index.js
+++ b/dist/index.js
@@ -2467,7 +2467,9 @@ const wrapRequire = new Proxy(require, {
             return target.apply(thisArg, [moduleID]);
         }
         catch (err) {
-            return target.resolve(moduleID, { paths: [...module.paths, process.cwd()] });
+            return target.resolve(moduleID, {
+                paths: module.paths.concat(process.cwd())
+            });
         }
     },
     get: (target, prop, receiver) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2427,7 +2427,7 @@ exports.request = request;
 /***/ }),
 
 /***/ 272:
-/***/ (function(module, __webpack_exports__, __webpack_require__) {
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
@@ -2455,7 +2455,6 @@ function callAsyncFunction(args, source) {
 var external_path_ = __webpack_require__(622);
 
 // CONCATENATED MODULE: ./src/wrap-require.ts
-/* module decorator */ module = __webpack_require__.hmd(module);
 
 const wrapRequire = new Proxy(require, {
     apply: (target, thisArg, [moduleID]) => {
@@ -2468,7 +2467,7 @@ const wrapRequire = new Proxy(require, {
         }
         catch (err) {
             return target.resolve(moduleID, {
-                paths: module.paths.concat(process.cwd())
+                paths: global.module.paths.concat(process.cwd())
             });
         }
     },
@@ -8809,29 +8808,6 @@ function regExpEscape (s) {
 /******/ 				function getModuleExports() { return module; };
 /******/ 			__webpack_require__.d(getter, 'a', getter);
 /******/ 			return getter;
-/******/ 		};
-/******/ 	}();
-/******/ 	
-/******/ 	/* webpack/runtime/harmony module decorator */
-/******/ 	!function() {
-/******/ 		__webpack_require__.hmd = function(module) {
-/******/ 			module = Object.create(module);
-/******/ 			if (!module.children) module.children = [];
-/******/ 			Object.defineProperty(module, 'loaded', {
-/******/ 				enumerable: true,
-/******/ 				get: function () { return module.l; }
-/******/ 			});
-/******/ 			Object.defineProperty(module, 'id', {
-/******/ 				enumerable: true,
-/******/ 				get: function () { return module.i; }
-/******/ 			});
-/******/ 			Object.defineProperty(module, 'exports', {
-/******/ 				enumerable: true,
-/******/ 				set: function () {
-/******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
-/******/ 				}
-/******/ 			});
-/******/ 			return module;
 /******/ 		};
 /******/ 	}();
 /******/ 	

--- a/dist/index.js
+++ b/dist/index.js
@@ -2896,7 +2896,7 @@ module.exports = require("assert");
 const wrapRequire = new Proxy(require, {
     apply: (target, thisArg, [moduleID]) => {
         if (moduleID.startsWith('.')) {
-            moduleID = path__WEBPACK_IMPORTED_MODULE_0__.join(process.cwd(), moduleID);
+            moduleID = path__WEBPACK_IMPORTED_MODULE_0__.resolve(moduleID);
             return target.apply(thisArg, [moduleID]);
         }
         try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2906,6 +2906,8 @@ const wrapRequire = new Proxy(require, {
             const modulePath = target.resolve.apply(thisArg, [
                 moduleID,
                 {
+                    // Webpack does not have an escape hatch for getting the actual
+                    // module, other than `eval`.
                     paths: eval('module').paths.concat(process.cwd())
                 }
             ]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -2494,6 +2494,7 @@ async function main() {
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
     const result = await callAsyncFunction({
         require: wrapRequire,
+        nativeRequire: require,
         github,
         context: lib_github.context,
         core: core,

--- a/dist/index.js
+++ b/dist/index.js
@@ -2427,7 +2427,7 @@ exports.request = request;
 /***/ }),
 
 /***/ 272:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
@@ -2455,13 +2455,20 @@ function callAsyncFunction(args, source) {
 var external_path_ = __webpack_require__(622);
 
 // CONCATENATED MODULE: ./src/wrap-require.ts
+/* module decorator */ module = __webpack_require__.hmd(module);
 
 const wrapRequire = new Proxy(require, {
     apply: (target, thisArg, [moduleID]) => {
         if (moduleID.startsWith('.')) {
             moduleID = Object(external_path_.join)(process.cwd(), moduleID);
+            return target.apply(thisArg, [moduleID]);
         }
-        return target.apply(thisArg, [moduleID]);
+        try {
+            return target.apply(thisArg, [moduleID]);
+        }
+        catch (err) {
+            return target.resolve(moduleID, { paths: [...module.paths, process.cwd()] });
+        }
     },
     get: (target, prop, receiver) => {
         Reflect.get(target, prop, receiver);
@@ -2494,7 +2501,7 @@ async function main() {
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
     const result = await callAsyncFunction({
         require: wrapRequire,
-        nativeRequire: require,
+        __original_require__: require,
         github,
         context: lib_github.context,
         core: core,
@@ -8800,6 +8807,29 @@ function regExpEscape (s) {
 /******/ 				function getModuleExports() { return module; };
 /******/ 			__webpack_require__.d(getter, 'a', getter);
 /******/ 			return getter;
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/harmony module decorator */
+/******/ 	!function() {
+/******/ 		__webpack_require__.hmd = function(module) {
+/******/ 			module = Object.create(module);
+/******/ 			if (!module.children) module.children = [];
+/******/ 			Object.defineProperty(module, 'loaded', {
+/******/ 				enumerable: true,
+/******/ 				get: function () { return module.l; }
+/******/ 			});
+/******/ 			Object.defineProperty(module, 'id', {
+/******/ 				enumerable: true,
+/******/ 				get: function () { return module.i; }
+/******/ 			});
+/******/ 			Object.defineProperty(module, 'exports', {
+/******/ 				enumerable: true,
+/******/ 				set: function () {
+/******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+/******/ 				}
+/******/ 			});
+/******/ 			return module;
 /******/ 		};
 /******/ 	}();
 /******/ 	

--- a/dist/index.js
+++ b/dist/index.js
@@ -2903,9 +2903,13 @@ const wrapRequire = new Proxy(require, {
             return target.apply(thisArg, [moduleID]);
         }
         catch (err) {
-            return target.resolve(moduleID, {
-                paths: eval('module').paths.concat(process.cwd())
-            });
+            const modulePath = target.resolve.apply(thisArg, [
+                moduleID,
+                {
+                    paths: eval('module').paths.concat(process.cwd())
+                }
+            ]);
+            return target.apply(thisArg, [modulePath]);
         }
     },
     get: (target, prop, receiver) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6144,7 +6144,7 @@ async function main() {
     const github = Object(lib_github.getOctokit)(token, opts);
     const script = Object(core.getInput)('script', { required: true });
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
-    const result = await callAsyncFunction({ require: __webpack_require__(875), github, context: lib_github.context, core: core, glob: glob, io: io }, script);
+    const result = await callAsyncFunction({ require: require, github, context: lib_github.context, core: core, glob: glob, io: io }, script);
     let encoding = Object(core.getInput)('result-encoding');
     encoding = encoding ? encoding : 'json';
     let output;
@@ -6900,25 +6900,6 @@ function expand(str, isTop) {
 }
 
 
-
-/***/ }),
-
-/***/ 875:
-/***/ (function(module) {
-
-function webpackEmptyContext(req) {
-	if (typeof req === 'number' && __webpack_require__.m[req])
-  return __webpack_require__(req);
-try { return require(req) }
-catch (e) { if (e.code !== 'MODULE_NOT_FOUND') throw e }
-var e = new Error("Cannot find module '" + req + "'");
-	e.code = 'MODULE_NOT_FOUND';
-	throw e;
-}
-webpackEmptyContext.keys = function() { return []; };
-webpackEmptyContext.resolve = webpackEmptyContext;
-module.exports = webpackEmptyContext;
-webpackEmptyContext.id = 875;
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,7 +40,7 @@ module.exports =
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(720);
+/******/ 		return __webpack_require__(272);
 /******/ 	};
 /******/ 	// initialize runtime
 /******/ 	runtime(__webpack_require__);
@@ -2422,6 +2422,104 @@ const request = withDefaults(endpoint.endpoint, {
 
 exports.request = request;
 //# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
+/***/ 272:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+
+// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
+var core = __webpack_require__(186);
+
+// EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
+var lib_github = __webpack_require__(438);
+
+// EXTERNAL MODULE: ./node_modules/@actions/glob/lib/glob.js
+var glob = __webpack_require__(90);
+
+// EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
+var io = __webpack_require__(436);
+
+// CONCATENATED MODULE: ./src/async-function.ts
+const AsyncFunction = Object.getPrototypeOf(async () => null).constructor;
+function callAsyncFunction(args, source) {
+    const fn = new AsyncFunction(...Object.keys(args), source);
+    return fn(...Object.values(args));
+}
+
+// EXTERNAL MODULE: external "path"
+var external_path_ = __webpack_require__(622);
+
+// CONCATENATED MODULE: ./src/wrap-require.ts
+
+const wrapRequire = new Proxy(require, {
+    apply: (target, thisArg, [moduleID]) => {
+        if (moduleID.startsWith('.')) {
+            moduleID = Object(external_path_.join)(process.cwd(), moduleID);
+        }
+        return target.apply(thisArg, [moduleID]);
+    },
+    get: (target, prop, receiver) => {
+        Reflect.get(target, prop, receiver);
+    }
+});
+
+// CONCATENATED MODULE: ./src/main.ts
+
+
+
+
+
+
+process.on('unhandledRejection', handleError);
+main().catch(handleError);
+async function main() {
+    const token = Object(core.getInput)('github-token', { required: true });
+    const debug = Object(core.getInput)('debug');
+    const userAgent = Object(core.getInput)('user-agent');
+    const previews = Object(core.getInput)('previews');
+    const opts = {};
+    if (debug === 'true')
+        opts.log = console;
+    if (userAgent != null)
+        opts.userAgent = userAgent;
+    if (previews != null)
+        opts.previews = previews.split(',');
+    const github = Object(lib_github.getOctokit)(token, opts);
+    const script = Object(core.getInput)('script', { required: true });
+    // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
+    const result = await callAsyncFunction({
+        require: wrapRequire,
+        github,
+        context: lib_github.context,
+        core: core,
+        glob: glob,
+        io: io
+    }, script);
+    let encoding = Object(core.getInput)('result-encoding');
+    encoding = encoding ? encoding : 'json';
+    let output;
+    switch (encoding) {
+        case 'json':
+            output = JSON.stringify(result);
+            break;
+        case 'string':
+            output = String(result);
+            break;
+        default:
+            throw new Error('"result-encoding" must be either "string" or "json"');
+    }
+    Object(core.setOutput)('result', output);
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleError(err) {
+    console.error(err);
+    Object(core.setFailed)(`Unhandled error: ${err}`);
+}
 
 
 /***/ }),
@@ -6093,101 +6191,6 @@ function issueCommand(command, message) {
 }
 exports.issueCommand = issueCommand;
 //# sourceMappingURL=file-command.js.map
-
-/***/ }),
-
-/***/ 720:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-
-// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
-var core = __webpack_require__(186);
-
-// EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
-var lib_github = __webpack_require__(438);
-
-// EXTERNAL MODULE: ./node_modules/@actions/glob/lib/glob.js
-var glob = __webpack_require__(90);
-
-// EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
-var io = __webpack_require__(436);
-
-// EXTERNAL MODULE: external "path"
-var external_path_ = __webpack_require__(622);
-
-// CONCATENATED MODULE: ./src/async-function.ts
-const AsyncFunction = Object.getPrototypeOf(async () => null).constructor;
-function callAsyncFunction(args, source) {
-    const fn = new AsyncFunction(...Object.keys(args), source);
-    return fn(...Object.values(args));
-}
-
-// CONCATENATED MODULE: ./src/main.ts
-
-
-
-
-
-
-process.on('unhandledRejection', handleError);
-main().catch(handleError);
-async function main() {
-    const token = Object(core.getInput)('github-token', { required: true });
-    const debug = Object(core.getInput)('debug');
-    const userAgent = Object(core.getInput)('user-agent');
-    const previews = Object(core.getInput)('previews');
-    const opts = {};
-    if (debug === 'true')
-        opts.log = console;
-    if (userAgent != null)
-        opts.userAgent = userAgent;
-    if (previews != null)
-        opts.previews = previews.split(',');
-    const github = Object(lib_github.getOctokit)(token, opts);
-    const script = Object(core.getInput)('script', { required: true });
-    // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
-    const result = await callAsyncFunction({
-        require: wrapRequire,
-        github,
-        context: lib_github.context,
-        core: core,
-        glob: glob,
-        io: io
-    }, script);
-    let encoding = Object(core.getInput)('result-encoding');
-    encoding = encoding ? encoding : 'json';
-    let output;
-    switch (encoding) {
-        case 'json':
-            output = JSON.stringify(result);
-            break;
-        case 'string':
-            output = String(result);
-            break;
-        default:
-            throw new Error('"result-encoding" must be either "string" or "json"');
-    }
-    Object(core.setOutput)('result', output);
-}
-const wrapRequire = new Proxy(require, {
-    apply: (target, thisArg, [moduleID]) => {
-        if (moduleID.startsWith('.')) {
-            moduleID = Object(external_path_.join)(process.cwd(), moduleID);
-        }
-        return target.apply(thisArg, [moduleID]);
-    },
-    get: (target, prop, receiver) => {
-        Reflect.get(target, prop, receiver);
-    }
-});
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function handleError(err) {
-    console.error(err);
-    Object(core.setFailed)(`Unhandled error: ${err}`);
-}
-
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,7 +40,7 @@ module.exports =
 /******/ 	// the startup function
 /******/ 	function startup() {
 /******/ 		// Load entry module and return exports
-/******/ 		return __webpack_require__(272);
+/******/ 		return __webpack_require__(720);
 /******/ 	};
 /******/ 	// initialize runtime
 /******/ 	runtime(__webpack_require__);
@@ -2426,113 +2426,6 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 272:
-/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-
-// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
-var core = __webpack_require__(186);
-
-// EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
-var lib_github = __webpack_require__(438);
-
-// EXTERNAL MODULE: ./node_modules/@actions/glob/lib/glob.js
-var glob = __webpack_require__(90);
-
-// EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
-var io = __webpack_require__(436);
-
-// CONCATENATED MODULE: ./src/async-function.ts
-const AsyncFunction = Object.getPrototypeOf(async () => null).constructor;
-function callAsyncFunction(args, source) {
-    const fn = new AsyncFunction(...Object.keys(args), source);
-    return fn(...Object.values(args));
-}
-
-// EXTERNAL MODULE: external "path"
-var external_path_ = __webpack_require__(622);
-
-// CONCATENATED MODULE: ./src/wrap-require.ts
-
-const wrapRequire = new Proxy(require, {
-    apply: (target, thisArg, [moduleID]) => {
-        if (moduleID.startsWith('.')) {
-            moduleID = Object(external_path_.join)(process.cwd(), moduleID);
-            return target.apply(thisArg, [moduleID]);
-        }
-        try {
-            return target.apply(thisArg, [moduleID]);
-        }
-        catch (err) {
-            return target.resolve(moduleID, {
-                paths: global.module.paths.concat(process.cwd())
-            });
-        }
-    },
-    get: (target, prop, receiver) => {
-        Reflect.get(target, prop, receiver);
-    }
-});
-
-// CONCATENATED MODULE: ./src/main.ts
-
-
-
-
-
-
-process.on('unhandledRejection', handleError);
-main().catch(handleError);
-async function main() {
-    const token = Object(core.getInput)('github-token', { required: true });
-    const debug = Object(core.getInput)('debug');
-    const userAgent = Object(core.getInput)('user-agent');
-    const previews = Object(core.getInput)('previews');
-    const opts = {};
-    if (debug === 'true')
-        opts.log = console;
-    if (userAgent != null)
-        opts.userAgent = userAgent;
-    if (previews != null)
-        opts.previews = previews.split(',');
-    const github = Object(lib_github.getOctokit)(token, opts);
-    const script = Object(core.getInput)('script', { required: true });
-    // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
-    const result = await callAsyncFunction({
-        require: wrapRequire,
-        __original_require__: require,
-        github,
-        context: lib_github.context,
-        core: core,
-        glob: glob,
-        io: io
-    }, script);
-    let encoding = Object(core.getInput)('result-encoding');
-    encoding = encoding ? encoding : 'json';
-    let output;
-    switch (encoding) {
-        case 'json':
-            output = JSON.stringify(result);
-            break;
-        case 'string':
-            output = String(result);
-            break;
-        default:
-            throw new Error('"result-encoding" must be either "string" or "json"');
-    }
-    Object(core.setOutput)('result', output);
-}
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function handleError(err) {
-    console.error(err);
-    Object(core.setFailed)(`Unhandled error: ${err}`);
-}
-
-
-/***/ }),
-
 /***/ 278:
 /***/ (function(__unusedmodule, exports) {
 
@@ -2989,6 +2882,37 @@ function escapeProperty(s) {
 /***/ (function(module) {
 
 module.exports = require("assert");
+
+/***/ }),
+
+/***/ 366:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "wrapRequire", function() { return wrapRequire; });
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(622);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
+
+const wrapRequire = new Proxy(require, {
+    apply: (target, thisArg, [moduleID]) => {
+        if (moduleID.startsWith('.')) {
+            moduleID = path__WEBPACK_IMPORTED_MODULE_0__.join(process.cwd(), moduleID);
+            return target.apply(thisArg, [moduleID]);
+        }
+        try {
+            return target.apply(thisArg, [moduleID]);
+        }
+        catch (err) {
+            return target.resolve(moduleID, {
+                paths: eval('module').paths.concat(process.cwd())
+            });
+        }
+    },
+    get: (target, prop, receiver) => {
+        Reflect.get(target, prop, receiver);
+    }
+});
+
 
 /***/ }),
 
@@ -6203,6 +6127,91 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
+/***/ 720:
+/***/ (function(__unusedmodule, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+
+// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
+var core = __webpack_require__(186);
+
+// EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
+var lib_github = __webpack_require__(438);
+
+// EXTERNAL MODULE: ./node_modules/@actions/glob/lib/glob.js
+var glob = __webpack_require__(90);
+
+// EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
+var io = __webpack_require__(436);
+
+// CONCATENATED MODULE: ./src/async-function.ts
+const AsyncFunction = Object.getPrototypeOf(async () => null).constructor;
+function callAsyncFunction(args, source) {
+    const fn = new AsyncFunction(...Object.keys(args), source);
+    return fn(...Object.values(args));
+}
+
+// EXTERNAL MODULE: ./src/wrap-require.ts
+var wrap_require = __webpack_require__(366);
+
+// CONCATENATED MODULE: ./src/main.ts
+
+
+
+
+
+
+process.on('unhandledRejection', handleError);
+main().catch(handleError);
+async function main() {
+    const token = Object(core.getInput)('github-token', { required: true });
+    const debug = Object(core.getInput)('debug');
+    const userAgent = Object(core.getInput)('user-agent');
+    const previews = Object(core.getInput)('previews');
+    const opts = {};
+    if (debug === 'true')
+        opts.log = console;
+    if (userAgent != null)
+        opts.userAgent = userAgent;
+    if (previews != null)
+        opts.previews = previews.split(',');
+    const github = Object(lib_github.getOctokit)(token, opts);
+    const script = Object(core.getInput)('script', { required: true });
+    // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
+    const result = await callAsyncFunction({
+        require: wrap_require.wrapRequire,
+        __original_require__: require,
+        github,
+        context: lib_github.context,
+        core: core,
+        glob: glob,
+        io: io
+    }, script);
+    let encoding = Object(core.getInput)('result-encoding');
+    encoding = encoding ? encoding : 'json';
+    let output;
+    switch (encoding) {
+        case 'json':
+            output = JSON.stringify(result);
+            break;
+        case 'string':
+            output = String(result);
+            break;
+        default:
+            throw new Error('"result-encoding" must be either "string" or "json"');
+    }
+    Object(core.setOutput)('result', output);
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleError(err) {
+    console.error(err);
+    Object(core.setFailed)(`Unhandled error: ${err}`);
+}
+
+
+/***/ }),
+
 /***/ 747:
 /***/ (function(module) {
 
@@ -8758,14 +8767,15 @@ function regExpEscape (s) {
 /******/ function(__webpack_require__) { // webpackRuntimeModules
 /******/ 	"use strict";
 /******/ 
-/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	/* webpack/runtime/compat get default export */
 /******/ 	!function() {
-/******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = function(exports) {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = function(module) {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				function getDefault() { return module['default']; } :
+/******/ 				function getModuleExports() { return module; };
+/******/ 			__webpack_require__.d(getter, 'a', getter);
+/******/ 			return getter;
 /******/ 		};
 /******/ 	}();
 /******/ 	
@@ -8777,6 +8787,17 @@ function regExpEscape (s) {
 /******/ 			if(!hasOwnProperty.call(exports, name)) {
 /******/ 				Object.defineProperty(exports, name, { enumerable: true, get: getter });
 /******/ 			}
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	!function() {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = function(exports) {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	}();
 /******/ 	
@@ -8796,18 +8817,6 @@ function regExpEscape (s) {
 /******/ 			Object.defineProperty(ns, 'default', { enumerable: true, value: value });
 /******/ 			if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
 /******/ 			return ns;
-/******/ 		};
-/******/ 	}();
-/******/ 	
-/******/ 	/* webpack/runtime/compat get default export */
-/******/ 	!function() {
-/******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__webpack_require__.n = function(module) {
-/******/ 			var getter = module && module.__esModule ?
-/******/ 				function getDefault() { return module['default']; } :
-/******/ 				function getModuleExports() { return module; };
-/******/ 			__webpack_require__.d(getter, 'a', getter);
-/******/ 			return getter;
 /******/ 		};
 /******/ 	}();
 /******/ 	

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github-script",
   "description": "A GitHub action for executing a simple script",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "author": "GitHub",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -13,7 +13,7 @@ type AsyncFunctionArguments = {
   glob: typeof glob
   io: typeof io
   require: NodeRequire
-  nativeRequire: NodeRequire
+  __original_require__: NodeRequire
 }
 
 export function callAsyncFunction<T>(

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import {Context} from '@actions/github/lib/context'
-import {GitHub} from '@actions/github/lib/utils'
+import { Context } from '@actions/github/lib/context'
+import { GitHub } from '@actions/github/lib/utils'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -13,6 +13,7 @@ type AsyncFunctionArguments = {
   glob: typeof glob
   io: typeof io
   require: NodeRequire
+  nativeRequire: NodeRequire
 }
 
 export function callAsyncFunction<T>(

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import { Context } from '@actions/github/lib/context'
-import { GitHub } from '@actions/github/lib/utils'
+import {Context} from '@actions/github/lib/context'
+import {GitHub} from '@actions/github/lib/utils'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 import {callAsyncFunction} from './async-function'
 
+declare const __non_webpack_require__: typeof require
+
 process.on('unhandledRejection', handleError)
 main().catch(handleError)
 
@@ -29,7 +31,7 @@ async function main(): Promise<void> {
 
   // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
   const result = await callAsyncFunction(
-    {require: require, github, context, core, glob, io},
+    {require: __non_webpack_require__, github, context, core, glob, io},
     script
   )
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ async function main(): Promise<void> {
   const result = await callAsyncFunction(
     {
       require: wrapRequire,
+      nativeRequire: __non_webpack_require__,
       github,
       context,
       core,

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   const result = await callAsyncFunction(
     {
       require: wrapRequire,
-      nativeRequire: __non_webpack_require__,
+      __original_require__: __non_webpack_require__,
       github,
       context,
       core,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,8 @@ import * as core from '@actions/core'
 import {context, getOctokit} from '@actions/github'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
-import * as path from 'path'
 import {callAsyncFunction} from './async-function'
-
-declare const __non_webpack_require__: NodeRequire
+import {wrapRequire} from './wrap-require'
 
 process.on('unhandledRejection', handleError)
 main().catch(handleError)
@@ -61,19 +59,6 @@ async function main(): Promise<void> {
 
   core.setOutput('result', output)
 }
-
-const wrapRequire = new Proxy(__non_webpack_require__, {
-  apply: (target, thisArg, [moduleID]) => {
-    if (moduleID.startsWith('.')) {
-      moduleID = path.join(process.cwd(), moduleID)
-    }
-    return target.apply(thisArg, [moduleID])
-  },
-
-  get: (target, prop, receiver) => {
-    Reflect.get(target, prop, receiver)
-  }
-})
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function handleError(err: any): void {

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -1,7 +1,5 @@
 import * as path from 'path'
 
-declare const __non_webpack_require__: NodeRequire
-
 export const wrapRequire = new Proxy(__non_webpack_require__, {
   apply: (target, thisArg, [moduleID]) => {
     if (moduleID.startsWith('.')) {

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -11,7 +11,7 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
       return target.apply(thisArg, [moduleID])
     } catch (err) {
       return target.resolve(moduleID, {
-        paths: global.module.paths.concat(process.cwd())
+        paths: eval('module').paths.concat(process.cwd())
       })
     }
   },

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -10,9 +10,14 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
     try {
       return target.apply(thisArg, [moduleID])
     } catch (err) {
-      return target.resolve(moduleID, {
-        paths: eval('module').paths.concat(process.cwd())
-      })
+      const modulePath = target.resolve.apply(thisArg, [
+        moduleID,
+        {
+          paths: eval('module').paths.concat(process.cwd())
+        }
+      ])
+
+      return target.apply(thisArg, [modulePath])
     }
   },
 

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -1,0 +1,16 @@
+import * as path from 'path'
+
+declare const __non_webpack_require__: NodeRequire
+
+export const wrapRequire = new Proxy(__non_webpack_require__, {
+  apply: (target, thisArg, [moduleID]) => {
+    if (moduleID.startsWith('.')) {
+      moduleID = path.join(process.cwd(), moduleID)
+    }
+    return target.apply(thisArg, [moduleID])
+  },
+
+  get: (target, prop, receiver) => {
+    Reflect.get(target, prop, receiver)
+  }
+})

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -13,6 +13,8 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
       const modulePath = target.resolve.apply(thisArg, [
         moduleID,
         {
+          // Webpack does not have an escape hatch for getting the actual
+          // module, other than `eval`.
           paths: eval('module').paths.concat(process.cwd())
         }
       ])

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -10,7 +10,9 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
     try {
       return target.apply(thisArg, [moduleID])
     } catch (err) {
-      return target.resolve(moduleID, {paths: [...module.paths, process.cwd()]})
+      return target.resolve(moduleID, {
+        paths: module.paths.concat(process.cwd())
+      })
     }
   },
 

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -11,7 +11,7 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
       return target.apply(thisArg, [moduleID])
     } catch (err) {
       return target.resolve(moduleID, {
-        paths: module.paths.concat(process.cwd())
+        paths: global.module.paths.concat(process.cwd())
       })
     }
   },

--- a/src/wrap-require.ts
+++ b/src/wrap-require.ts
@@ -4,8 +4,14 @@ export const wrapRequire = new Proxy(__non_webpack_require__, {
   apply: (target, thisArg, [moduleID]) => {
     if (moduleID.startsWith('.')) {
       moduleID = path.join(process.cwd(), moduleID)
+      return target.apply(thisArg, [moduleID])
     }
-    return target.apply(thisArg, [moduleID])
+
+    try {
+      return target.apply(thisArg, [moduleID])
+    } catch (err) {
+      return target.resolve(moduleID, {paths: [...module.paths, process.cwd()]})
+    }
   },
 
   get: (target, prop, receiver) => {

--- a/types/non-webpack-require.ts
+++ b/types/non-webpack-require.ts
@@ -1,0 +1,1 @@
+declare const __non_webpack_require__: NodeRequire


### PR DESCRIPTION
This adds support for the following:

- Requiring modules by a path relative to the working directory `require('./foo')` 
- Requiring npm modules installed in the working directory `require('lodash')`

This is accomplished by wrapping the `require` passed to the script in a proxy.

- When the script calls `require` with a path that starts with `'.'`, we transform that module ID to the result of `path.join(process.cwd(), moduleID)` and then require the absolute path, instead.
- When a script calls `require` for some non-relative path and an error is thrown, we catch that error and try again, this time adding `process.cwd()` to the list of paths searched-through.

Thanks to @joshmgross and @wraithgar for doing the real work here 😄 