### PR TITLE
Add instructions for using a separate GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,3 +350,32 @@ jobs:
 
             console.log(`Hello ${FIRST_NAME} ${LAST_NAME}`)
 ```
+
+### Using a separate GitHub token
+
+The `GITHUB_TOKEN` used by default is scoped to the current repository, see [Authentication in a workflow](https://docs.github.com/actions/reference/authentication-in-a-workflow).
+
+If you need access to a different repository or an API that the `GITHUB_TOKEN` doesn't have permissions to, you can provide your own [PAT](https://help.github.com/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) as a secret using the `github-token` input.
+
+[Learn more about creating and using encrypted secrets](https://docs.github.com/actions/reference/encrypted-secrets)
+
+```yaml
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.MY_PAT }}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Triage']
+            })
+```


### PR DESCRIPTION
#145 removed the `github-token` usage in the examples so that users could copy and paste the examples without any extra configuration.

Most users will not need a separate GitHub token and the previous example of `secrets.GITHUB_TOKEN` was not a valid secret name, so some modification was always required.

This PR adds a new example so that users know how to provide their own GitHub token.