### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,20 @@
 name: CI
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with: {node-version: 13.x}
-      - uses: actions/cache@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,10 @@
 name: Integration
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   test-return:
@@ -39,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,8 +1,10 @@
 name: Licensed
 
 on:
-  push: {branches: main}
-  pull_request: {branches: main}
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   repository_dispatch:
   workflow_dispatch:
 
@@ -12,7 +14,7 @@ jobs:
     name: Check licenses
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -2,7 +2,7 @@ name: Pull Request Test
 
 on:
   pull_request:
-    branches: main
+    branches: [main]
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
This updates the workflows to

1. Use the full syntax for `on.[push|pull_request].branches`
2. Use the latest versions of `actions/cache` and `actions/setup-node`
3. Use Node 12 in workflows to match the Node version that javascript actions are run with