### PR TITLE
docs(readme): fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ And then export an async function from your module:
 ```javascript
 module.exports = async ({github, context, core}) => {
   const {SHA} = process.env
-  const commit = await github.repos.getCommit({
+  const commit = await github.rest.repos.getCommit({
     owner: context.repo.owner,
     repo: context.repo.repo,
     ref: `${SHA}`


### PR DESCRIPTION
Fix an example in the README that was missing the `rest` part in the API call.