### PR TITLE
Update README with Markdown text formatting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ jobs:
 
 ### Welcome a first-time contributor
 
+You can format text in comments using the same [Markdown syntax](https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) as the GitHub web interface:
+
 ```yaml
 on: pull_request
 
@@ -180,7 +182,9 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Welcome, new contributor!'
+              body: `**Welcome**, new contributor!
+
+                Please make sure you're read our [contributing guide](CONTRIBUTING.md) and we look forward to reviewing your Pull request shortly ✨`
             })
 ```
 


### PR DESCRIPTION
Adds a link to the GitHub docs on text formatting, and updates the "Welcome a first-time contributor" to include a multi-line Markdown string.

Fixes #247