### PR TITLE
Fix overriding request options from @actions/github

### DIFF
--- a/.licenses/npm/@actions/github.dep.yml
+++ b/.licenses/npm/@actions/github.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/github"
-version: 5.1.0
+version: 5.1.1
 type: npm
 summary: Actions github lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/github

--- a/__test__/get-retry-options.test.ts
+++ b/__test__/get-retry-options.test.ts
@@ -4,38 +4,66 @@ import {getRetryOptions} from '../src/retry-options'
 
 describe('getRequestOptions', () => {
   test('retries disabled if retries == 0', async () => {
-    const [retryOptions, requestOptions] = getRetryOptions(0, [400, 500, 502])
+    const [retryOptions, requestOptions] = getRetryOptions(
+      0,
+      [400, 500, 502],
+      []
+    )
 
     expect(retryOptions.enabled).toBe(false)
     expect(retryOptions.doNotRetry).toBeFalsy()
 
-    expect(requestOptions.retries).toBeFalsy()
+    expect(requestOptions?.retries).toBeFalsy()
   })
 
   test('properties set if retries > 0', async () => {
-    const [retryOptions, requestOptions] = getRetryOptions(1, [400, 500, 502])
+    const [retryOptions, requestOptions] = getRetryOptions(
+      1,
+      [400, 500, 502],
+      []
+    )
 
     expect(retryOptions.enabled).toBe(true)
     expect(retryOptions.doNotRetry).toEqual([400, 500, 502])
 
-    expect(requestOptions.retries).toEqual(1)
+    expect(requestOptions?.retries).toEqual(1)
   })
 
   test('properties set if retries > 0', async () => {
-    const [retryOptions, requestOptions] = getRetryOptions(1, [400, 500, 502])
+    const [retryOptions, requestOptions] = getRetryOptions(
+      1,
+      [400, 500, 502],
+      []
+    )
 
     expect(retryOptions.enabled).toBe(true)
     expect(retryOptions.doNotRetry).toEqual([400, 500, 502])
 
-    expect(requestOptions.retries).toEqual(1)
+    expect(requestOptions?.retries).toEqual(1)
   })
 
   test('retryOptions.doNotRetry not set if exemptStatusCodes isEmpty', async () => {
-    const [retryOptions, requestOptions] = getRetryOptions(1, [])
+    const [retryOptions, requestOptions] = getRetryOptions(1, [], [])
 
     expect(retryOptions.enabled).toBe(true)
     expect(retryOptions.doNotRetry).toBeUndefined()
 
-    expect(requestOptions.retries).toEqual(1)
+    expect(requestOptions?.retries).toEqual(1)
+  })
+
+  test('requestOptions does not override defaults from @actions/github', async () => {
+    const [retryOptions, requestOptions] = getRetryOptions(1, [], {
+      request: {
+        agent: 'default-user-agent'
+      },
+      foo: 'bar'
+    })
+
+    expect(retryOptions.enabled).toBe(true)
+    expect(retryOptions.doNotRetry).toBeUndefined()
+
+    expect(requestOptions?.retries).toEqual(1)
+    expect(requestOptions?.agent).toEqual('default-user-agent')
+    expect(requestOptions?.foo).toBeUndefined() // this should not be in the `options.request` object, but at the same level as `request`
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-script",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "github-script",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.0.tgz",
-      "integrity": "sha512-tuI80F7JQIhg77ZTTgUAPpVD7ZnP9oHSPN8xw7LOwtA4vEMbAjWJNbmLBfV7xua7r016GyjzWLuec5cs8f/a8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "@octokit/core": "^3.6.0",
@@ -6242,9 +6242,9 @@
       }
     },
     "@actions/github": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.0.tgz",
-      "integrity": "sha512-tuI80F7JQIhg77ZTTgUAPpVD7ZnP9oHSPN8xw7LOwtA4vEMbAjWJNbmLBfV7xua7r016GyjzWLuec5cs8f/a8A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
       "requires": {
         "@actions/http-client": "^2.0.1",
         "@octokit/core": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github-script",
   "description": "A GitHub action for executing a simple script",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "author": "GitHub",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,13 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import {context, getOctokit} from '@actions/github'
+import {defaults as defaultGitHubOptions} from '@actions/github/lib/utils'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
 import {retry} from '@octokit/plugin-retry'
+import {RequestRequestOptions} from '@octokit/types'
 import {callAsyncFunction} from './async-function'
-import {
-  getRetryOptions,
-  parseNumberArray,
-  RequestOptions,
-  RetryOptions
-} from './retry-options'
+import {getRetryOptions, parseNumberArray, RetryOptions} from './retry-options'
 import {wrapRequire} from './wrap-require'
 
 process.on('unhandledRejection', handleError)
@@ -21,7 +18,7 @@ type Options = {
   userAgent?: string
   previews?: string[]
   retry?: RetryOptions
-  request?: RequestOptions
+  request?: RequestRequestOptions
 }
 
 async function main(): Promise<void> {
@@ -33,7 +30,11 @@ async function main(): Promise<void> {
   const exemptStatusCodes = parseNumberArray(
     core.getInput('retry-exempt-status-codes')
   )
-  const [retryOpts, requestOpts] = getRetryOptions(retries, exemptStatusCodes)
+  const [retryOpts, requestOpts] = getRetryOptions(
+    retries,
+    exemptStatusCodes,
+    defaultGitHubOptions
+  )
 
   const opts: Options = {}
   if (debug === 'true') opts.log = console

--- a/src/retry-options.ts
+++ b/src/retry-options.ts
@@ -1,20 +1,19 @@
 import * as core from '@actions/core'
+import {OctokitOptions} from '@octokit/core/dist-types/types'
+import {RequestRequestOptions} from '@octokit/types'
 
 export type RetryOptions = {
   doNotRetry?: number[]
   enabled?: boolean
 }
 
-export type RequestOptions = {
-  retries?: number
-}
-
 export function getRetryOptions(
   retries: number,
-  exemptStatusCodes: number[]
-): [RetryOptions, RequestOptions] {
+  exemptStatusCodes: number[],
+  defaultOptions: OctokitOptions
+): [RetryOptions, RequestRequestOptions | undefined] {
   if (retries <= 0) {
-    return [{enabled: false}, {}]
+    return [{enabled: false}, defaultOptions.request]
   }
 
   const retryOptions: RetryOptions = {
@@ -25,7 +24,11 @@ export function getRetryOptions(
     retryOptions.doNotRetry = exemptStatusCodes
   }
 
-  const requestOptions: RequestOptions = {
+  // The GitHub type has some defaults for `options.request`
+  // see: https://github.com/actions/toolkit/blob/4fbc5c941a57249b19562015edbd72add14be93d/packages/github/src/utils.ts#L15
+  // We pass these in here so they are not overidden.
+  const requestOptions: RequestRequestOptions = {
+    ...defaultOptions.request,
     retries
   }
 


### PR DESCRIPTION
# Problem
Since introducing retries in #288, we would override the `request` field of the `OctokitOptions` we pass into the `getOctokit` method. The problem is that the `@actions/github` package also provides some defaults for the `request` field. [source](https://github.com/actions/toolkit/blob/4fbc5c941a57249b19562015edbd72add14be93d/packages/github/src/utils.ts#L15). Some users rely on these defaults and would break since we added retries.

Behavior: 

If we have these defaults:
```js
{
  request: {
    agent: 'some-agent'
  }
}
```

and add these options: 
```js
{
  request: {
    retries: 2
  }
}
```

we get the following output: 
```js
{
  request: {
    retries: 2
  }
}
```

Note the original options are completely overriden, which is not desired. 


# Solution
We copy the default `options.request` fields from the `@actions/github` package into the `request` field when we add the `retries` field. 

Fixed behavior:

if we have these defaults:
```js
{
  request: {
    agent: 'some-agent'
  }
}
```

and add these options: 
```js
{
  request: {
    retries: 2
  }
}
```

we get the following output: 
```js
{
  request: {
    agent: 'some-agent',
    retries: 2
  }
}
```

fixes #291 
