### PR TITLE
Update license for minmatch

### DIFF
--- a/.licenses/npm/minimatch.dep.yml
+++ b/.licenses/npm/minimatch.dep.yml
@@ -1,9 +1,9 @@
 ---
 name: minimatch
-version: 3.0.4
+version: 3.1.2
 type: npm
 summary: a glob matcher in javascript
-homepage: https://github.com/isaacs/minimatch#readme
+homepage:
 license: isc
 licenses:
 - sources: LICENSE


### PR DESCRIPTION
#320 updated `minimatch` but the license wasn't updated, breaking that CI build.

This should fix it.