### PR TITLE
Prepare release v4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-script",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "github-script",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github-script",
   "description": "A GitHub action for executing a simple script",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "author": "GitHub",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
As part of #349 we updated the version to `4.1.0`, but we already had `4.1.0` and for `4.1.1`. This bumps version to `4.2.0`.