### PR TITLE
Add @octokit/plugin-request-log, to produce debug output for requests

### DIFF
--- a/.licenses/npm/@octokit/plugin-request-log.dep.yml
+++ b/.licenses/npm/@octokit/plugin-request-log.dep.yml
@@ -1,0 +1,20 @@
+---
+name: "@octokit/plugin-request-token"
+version: 1.0.4
+type: npm
+summary: GitHub API token authentication for browsers and Node.js
+homepage: https://github.com/octokit/plugin-request-log.js#readme
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License Copyright (c) 2019 Octokit contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: "[MIT](LICENSE)"
+notices: []

--- a/dist/index.js
+++ b/dist/index.js
@@ -6544,6 +6544,45 @@ exports.paginatingEndpoints = paginatingEndpoints;
 
 /***/ }),
 
+/***/ 8883:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+var __webpack_unused_export__;
+
+
+__webpack_unused_export__ = ({ value: true });
+
+const VERSION = "1.0.4";
+
+/**
+ * @param octokit Octokit instance
+ * @param options Options passed to Octokit constructor
+ */
+
+function requestLog(octokit) {
+  octokit.hook.wrap("request", (request, options) => {
+    octokit.log.debug("request", options);
+    const start = Date.now();
+    const requestOptions = octokit.request.endpoint.parse(options);
+    const path = requestOptions.url.replace(options.baseUrl, "");
+    return request(options).then(response => {
+      octokit.log.info(`${requestOptions.method} ${path} - ${response.status} in ${Date.now() - start}ms`);
+      return response;
+    }).catch(error => {
+      octokit.log.info(`${requestOptions.method} ${path} - ${error.status} in ${Date.now() - start}ms`);
+      throw error;
+    });
+  });
+}
+requestLog.VERSION = VERSION;
+
+exports.g = requestLog;
+//# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
 /***/ 6298:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -15091,8 +15130,10 @@ var utils = __nccwpck_require__(3030);
 var glob = __nccwpck_require__(8090);
 // EXTERNAL MODULE: ./node_modules/@actions/io/lib/io.js
 var io = __nccwpck_require__(7436);
+// EXTERNAL MODULE: ./node_modules/@octokit/plugin-request-log/dist-node/index.js
+var dist_node = __nccwpck_require__(8883);
 // EXTERNAL MODULE: ./node_modules/@octokit/plugin-retry/dist-node/index.js
-var dist_node = __nccwpck_require__(6298);
+var plugin_retry_dist_node = __nccwpck_require__(6298);
 ;// CONCATENATED MODULE: ./src/async-function.ts
 const AsyncFunction = Object.getPrototypeOf(async () => null).constructor;
 function callAsyncFunction(args, source) {
@@ -15171,6 +15212,7 @@ var lib_default = /*#__PURE__*/__nccwpck_require__.n(lib);
 
 
 
+
 process.on('unhandledRejection', handleError);
 main().catch(handleError);
 async function main() {
@@ -15192,7 +15234,7 @@ async function main() {
         opts.retry = retryOpts;
     if (requestOpts)
         opts.request = requestOpts;
-    const github = (0,lib_github.getOctokit)(token, opts, dist_node/* retry */.XD);
+    const github = (0,lib_github.getOctokit)(token, opts, plugin_retry_dist_node/* retry */.XD, dist_node/* requestLog */.g);
     const script = core.getInput('script', { required: true });
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.
     const result = await callAsyncFunction({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@actions/io": "^1.1.1",
         "@octokit/core": "^3.5.1",
         "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-request-log": "^1.0.4",
         "@octokit/plugin-rest-endpoint-methods": "^6.3.0",
         "@octokit/plugin-retry": "^3.0.9",
         "node-fetch": "^2.6.7"
@@ -1123,6 +1124,14 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -7091,6 +7100,12 @@
       "requires": {
         "@octokit/types": "^6.34.0"
       }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@actions/io": "^1.1.1",
     "@octokit/core": "^3.5.1",
     "@octokit/plugin-paginate-rest": "^2.17.0",
+    "@octokit/plugin-request-log": "^1.0.4",
     "@octokit/plugin-rest-endpoint-methods": "^6.3.0",
     "@octokit/plugin-retry": "^3.0.9",
     "node-fetch": "^2.6.7"

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {context, getOctokit} from '@actions/github'
 import {defaults as defaultGitHubOptions} from '@actions/github/lib/utils'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
+import {requestLog} from '@octokit/plugin-request-log'
 import {retry} from '@octokit/plugin-retry'
 import {RequestRequestOptions} from '@octokit/types'
 import {callAsyncFunction} from './async-function'
@@ -44,7 +45,7 @@ async function main(): Promise<void> {
   if (retryOpts) opts.retry = retryOpts
   if (requestOpts) opts.request = requestOpts
 
-  const github = getOctokit(token, opts, retry)
+  const github = getOctokit(token, opts, retry, requestLog)
   const script = core.getInput('script', {required: true})
 
   // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.


### PR DESCRIPTION
Without this plugin, the debug setting is, effectively, meaningless as
none of the existing plugins produce log output.

The plugin writes the request options to octokit.log.debug, and response
times as *method path - status in ...ms* to octokit.log.info.

Fixes #265
