### PR TITLE
Remove path filters from check-dist workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -10,11 +10,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This workflow is a required status check, so we can't skip running it.

This is preventing #285 from merging