### PR TITLE
doc: Explain differencs in CWD when run in a composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,23 @@ Additionally, you'll want to use the [checkout
 action](https://github.com/actions/checkout) to make sure your script file is
 available.
 
+### Running in Composite Actions
+
+When used from a composite-action the current working directory is the invoking workflow,
+*not* the composite action's. Be sure to use an absolute path to any of the action's
+resources in this case like so:
+
+```yaml
+name: My Composite Action Using Github Scripts
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      script: |
+          const script = require(process.env.GITHUB_ACTION_PATH + '/my-action-main.js')
+          console.log(script({context, core})
+```
+
 ### Run a separate file with an async function
 
 You can also use async functions in this manner, as long as you `await` it in


### PR DESCRIPTION
This documents an easy to make mistake regarding how
to require a resource from the action's source. When a relative
path is used, the CWD is the workflow's not the composite
action's. This surfaces to calling workflows as a
`MODULE_NOT_FOUND` error.

Note, ideally we'd use the `github.action_path` (or soon, `github.host-workspace`) context in our example. But until actions/runner#2517 is completed, it's safer to use `process.env.GITHUB_ACTION_PATH` which is correct regardless of how the action is invoked.