### PR TITLE
Add more issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question or provide feedback about using this action
+    about: For general Q&A and feedback, see the Discussions tab.
+    url: https://github.com/actions/github-script/discussions
+  - name: Ask a question or provide feedback about GitHub Actions
+    about: Please check out the GitHub community forum for discussions about GitHub Actions
+    url: https://github.com/orgs/community/discussions/categories/actions


### PR DESCRIPTION
For general feedback or questions, we should direct users to a more appropriate place than an issue.

This is similar to the template used by https://github.com/actions/languageservices