### PR TITLE
Add `allow-empty-token` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: The GitHub token used to create an authenticated client
     default: ${{ github.token }}
     required: false
+  allow-empty-token:
+    description: Whether to allow for the github-token to be empty. If true, and the github-token is empty, results in anonymous API calls.
+    default: false
+    required: false
   debug:
     description: Whether to tell the GitHub client to log details of its requests. true or false. Default is to run in debug mode when the GitHub Actions step debug logging is turned on.
     default: ${{ runner.debug == '1' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@actions/github": "^5.0.0",
         "@actions/glob": "^0.3.0",
         "@actions/io": "^1.1.1",
+        "@octokit/auth-unauthenticated": "^3.0.5",
         "@octokit/core": "^3.5.1",
         "@octokit/plugin-request-log": "^1.0.4",
         "@octokit/plugin-retry": "^3.0.9",
@@ -1072,6 +1073,44 @@
       "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "dependencies": {
         "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-3.0.5.tgz",
+      "integrity": "sha512-yH2GPFcjrTvDWPwJWWCh0tPPtTL5SMgivgKPA+6v/XmYN6hGQkAto8JtZibSKOpf8ipmeYhLNWQ2UgW0GYILCw==",
+      "dependencies": {
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
+    },
+    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "node_modules/@octokit/core": {
@@ -7022,6 +7061,40 @@
       "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "requires": {
         "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/auth-unauthenticated": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-3.0.5.tgz",
+      "integrity": "sha512-yH2GPFcjrTvDWPwJWWCh0tPPtTL5SMgivgKPA+6v/XmYN6hGQkAto8JtZibSKOpf8ipmeYhLNWQ2UgW0GYILCw==",
+      "requires": {
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "17.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
+        },
+        "@octokit/request-error": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+          "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+          "requires": {
+            "@octokit/types": "^9.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "9.2.3",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
+          "requires": {
+            "@octokit/openapi-types": "^17.2.0"
+          }
+        }
       }
     },
     "@octokit/core": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@actions/github": "^5.0.0",
     "@actions/glob": "^0.3.0",
     "@actions/io": "^1.1.1",
+    "@octokit/auth-unauthenticated": "^3.0.5",
     "@octokit/core": "^3.5.1",
     "@octokit/plugin-request-log": "^1.0.4",
     "@octokit/plugin-retry": "^3.0.9",


### PR DESCRIPTION
Fixes #396 by adding a new `allow-empty-token` input which if true, permits an empty `github-token`.

Tested locally with an action that `GET`s a PR, then tries to add a label. `GET` is OK, `POST` results in:

```
| RequestError [HttpError]: Unauthorized. "POST /repos/{owner}/{repo}/issues/{issue_number}/labels" failed most likely due to lack of authentication. Reason: No github-token was provided to actions/github-scripts, and allow-empty-token is true
```