### PR TITLE
feat(runner): use node20 by default

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run style:check

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ documentation.
 
 ## Breaking Changes
 
+### Breaking changes in V7
+
+Version 7 of this action updated the runtime to Node 20 - https://github.com/github/docs/issues/28156
+
+All scripts are now run with Node 20 instead of Node 16 and are affected by any breaking changes between Node 16 and 20.
+
+
 ### Breaking changes in V6
 
 Version 6 of this action updated the runtime to Node 16 - https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-using-nodejs-v16
@@ -377,7 +384,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci
       # or one-off:
       - run: npm install execa

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Hello There 👋 

Since the last node20 runner + the end of life of node16 i would like to run my actions in node20 🙏 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Thank you for the awesome you do btw <3 