### PR TITLE
Avoid setting `baseUrl` to undefined when input is not provided

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -248,3 +248,78 @@ jobs:
           done <<< "$tests"
 
           echo $'\u2705 Test passed' | tee -a $GITHUB_STEP_SUMMARY
+
+  test-base-url:
+    name: 'Integration test: base-url option'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install-dependencies
+
+      - id: base-url-default
+        name: API URL with base-url not set
+        uses: ./
+        with:
+          script: |
+            const endpoint = github.request.endpoint
+            return endpoint({}).url
+          result-encoding: string
+
+      - id: base-url-default-graphql
+        name: GraphQL URL with base-url not set
+        uses: ./
+        with:
+          script: |
+            const endpoint = github.request.endpoint
+            return endpoint({url: "/graphql"}).url
+          result-encoding: string
+
+      - id: base-url-set
+        name: API URL with base-url set
+        uses: ./
+        with:
+          base-url: https://my.github-enterprise-server.com/api/v3
+          script: |
+            const endpoint = github.request.endpoint
+            return endpoint({}).url
+          result-encoding: string
+
+      - id: base-url-set-graphql
+        name: GraphQL URL with base-url set
+        uses: ./
+        with:
+          base-url: https://my.github-enterprise-server.com/api/v3
+          script: |
+            const endpoint = github.request.endpoint
+            return endpoint({url: "/graphql"}).url
+          result-encoding: string
+
+      - run: |
+          echo "- Validating API URL default"
+          expected="https://api.github.com/"
+          actual="${{steps.base-url-default.outputs.result}}"
+          if [[ "$expected" != "$actual" ]]; then
+            echo $'::error::\u274C' "Expected base-url to equal '$expected', got $actual"
+            exit 1
+          fi
+          echo "- Validating GraphQL URL default"
+          expected="https://api.github.com/graphql"
+          actual="${{steps.base-url-default-graphql.outputs.result}}"
+          if [[ "$expected" != "$actual" ]]; then
+            echo $'::error::\u274C' "Expected base-url to equal '$expected', got $actual"
+            exit 1
+          fi
+          echo "- Validating base-url set to a value"
+          expected="https://my.github-enterprise-server.com/api/v3/"
+          actual="${{steps.base-url-set.outputs.result}}"
+          if [[ "$expected" != "$actual" ]]; then
+            echo $'::error::\u274C' "Expected base-url to equal '$expected', got $actual"
+            exit 1
+          fi
+          echo "- Validating GraphQL URL with base-url set to a value"
+          expected="https://my.github-enterprise-server.com/api/v3/graphql"
+          actual="${{steps.base-url-set-graphql.outputs.result}}"
+          if [[ "$expected" != "$actual" ]]; then
+            echo $'::error::\u274C' "Expected base-url to equal '$expected', got $actual"
+            exit 1
+          fi

--- a/dist/index.js
+++ b/dist/index.js
@@ -35509,9 +35509,13 @@ async function main() {
         userAgent: userAgent || undefined,
         previews: previews ? previews.split(',') : undefined,
         retry: retryOpts,
-        request: requestOpts,
-        baseUrl: baseUrl || undefined
+        request: requestOpts
     };
+    // Setting `baseUrl` to undefined will prevent the default value from being used
+    // https://github.com/actions/github-script/issues/436
+    if (baseUrl) {
+        opts.baseUrl = baseUrl;
+    }
     const github = (0,lib_github.getOctokit)(token, opts, plugin_retry_dist_node.retry, dist_node.requestLog);
     const script = core.getInput('script', { required: true });
     // Using property/value shorthand on `require` (e.g. `{require}`) causes compilation errors.

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,8 +44,13 @@ async function main(): Promise<void> {
     userAgent: userAgent || undefined,
     previews: previews ? previews.split(',') : undefined,
     retry: retryOpts,
-    request: requestOpts,
-    baseUrl: baseUrl || undefined
+    request: requestOpts
+  }
+
+  // Setting `baseUrl` to undefined will prevent the default value from being used
+  // https://github.com/actions/github-script/issues/436
+  if (baseUrl) {
+    opts.baseUrl = baseUrl
   }
 
   const github = getOctokit(token, opts, retry, requestLog)


### PR DESCRIPTION
Fixes #436 

Replaces #437

Due to how options are passed through `@actions/github` to Octokit, an `undefined` `baseUrl` prevents the default from being used. This breaks using github-script on GHES, which requires the GHES instance API URL.

#437 attempted to reproduce this issue in a test, but it was unsuccessful. There's a similar issue in the integration test, but the fix doesn't work despite it being confirmed in https://github.com/actions/github-script/issues/436#issuecomment-1816670425.
I've included the other integration tests, but they don't cover this specific scenario or what we're trying to fix.