### PR TITLE
chore: Use "explicit" when editor.codeActionsOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
   "files.exclude": {
     "**/dist": true,


### PR DESCRIPTION
## About

This PR follows new options:

- `explicit`: Triggers Code Actions when explicitly saved. Same as `true`.
- `always`: Triggers Code Actions when explicitly saved and on Auto Saves from window or focus changes.
- `never`: Never triggers Code Actions on save. Same as false.

## References

https://code.visualstudio.com/updates/v1_83#_code-actions-on-save-and-auto-save