### PR TITLE
chore: Bump actions/checkout + actions/setup-node from v3 to v4

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,7 +3,7 @@ description: 'Set up node and install dependencies'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         cache: npm

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/install-dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - run: npm run style:check
       - run: npm test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     name: 'Integration test: return'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: output-set
         uses: ./
         with:
@@ -31,7 +31,7 @@ jobs:
     name: 'Integration test: relative-path require'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: relative-require
         uses: ./
         with:
@@ -49,7 +49,7 @@ jobs:
     name: 'Integration test: npm package require'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - id: npm-require
         uses: ./
@@ -69,7 +69,7 @@ jobs:
     name: 'Integration test: GraphQL previews option'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - id: previews-default
         name: Default previews not set
@@ -122,7 +122,7 @@ jobs:
     name: 'Integration test: user-agent option'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - id: user-agent-default
         name: Default user-agent not set
@@ -179,7 +179,7 @@ jobs:
     name: "Integration test: debug option (runner.debug mode ${{ matrix.environment && 'enabled' || 'disabled' }})"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - id: debug-default
         name: Default debug not set
@@ -253,7 +253,7 @@ jobs:
     name: 'Integration test: base-url option'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
 
       - id: base-url-default

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # prefer to use a full fetch for licensed workflows
       # https://github.com/jonabc/setup-licensed/releases/tag/v1.1.1

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -9,7 +9,7 @@ jobs:
   pull-request-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           script: |

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ jobs:
   echo-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
           script: |
@@ -343,7 +343,7 @@ jobs:
   echo-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         env:
           SHA: '${{env.parentSHA}}'
@@ -381,7 +381,7 @@ jobs:
   echo-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '20.x'
@@ -417,7 +417,7 @@ jobs:
   print-stuff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## References

- https://github.com/actions/checkout/compare/v3...v4.0.0
- https://github.com/actions/setup-node/compare/v3...v4.0.0
