### PR TITLE
docs: fix jsdoc example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ $ npm i -D @types/github-script@github:actions/github-script
 And then add the `jsDoc` declaration to your script like this:
 ```js
 // @ts-check
-/** @param {import('@types/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+/** @param {import('github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 export default async ({ core, context }) => {
   core.debug("Running something at the moment");
   return context.actor;


### PR DESCRIPTION
Hi there 👋 

Ran into this one, when trying our the action. Types shouldn't be imported directly from `@types/github-script` but from `github-script` directly.

![image](https://github.com/actions/github-script/assets/31937175/28d3512e-c48f-400f-8fc3-ff74cdaea393)
![image](https://github.com/actions/github-script/assets/31937175/89899634-9d63-4cc7-b4a2-8c1c0407a3da)
