### PR TITLE
chore: Add Dependabot for NPM and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Few of the built-in actions are behind by one major. Seems like only the Dependabot Security PRs are being sent right now