### PR TITLE
Upgrade husky to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run pre-commit && git add dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
-        "husky": "^7.0.0",
+        "husky": "^9.1.1",
         "jest": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.3",
@@ -4045,15 +4045,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.1.tgz",
+      "integrity": "sha512-fCqlqLXcBnXa/TJXmT93/A36tJsjdJkibQ1MuIiFyCCYUlpYpIaj2mv1w+3KR6Rzu1IC3slFTje5f6DUp2A2rg==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -10325,9 +10325,9 @@
       "dev": true
     },
     "husky": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.2.tgz",
-      "integrity": "sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.1.tgz",
+      "integrity": "sha512-fCqlqLXcBnXa/TJXmT93/A36tJsjdJkibQ1MuIiFyCCYUlpYpIaj2mv1w+3KR6Rzu1IC3slFTje5f6DUp2A2rg==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "style:write": "run-p --continue-on-error --aggregate-output format:write lint",
     "pre-commit": "run-s style:write test build",
     "test": "jest",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "jest": {
     "preset": "ts-jest",
@@ -57,7 +57,7 @@
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "husky": "^7.0.0",
+    "husky": "^9.1.1",
     "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Migrate to husky v9 following the instructions in their [release notes](https://github.com/typicode/husky/releases/tag/v9.0.1).

For context, I got the following husky error when [installing this package for JSDoc support](https://github.com/actions/github-script?tab=readme-ov-file#use-scripts-with-jsdoc-support):

```logs
❱ npm i -D @types/github-script@github:actions/github-script
npm ERR! code 1
npm ERR! git dep preparation failed
npm ERR! command npm install --force --cache=/home/****/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
npm ERR! > github-script@7.0.1 prepare
npm ERR! > husky install
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! .git can't be found (see https://git.io/Jc3F9)
npm ERR! npm ERR! code 1
npm ERR! npm ERR! path /home/*****/.npm/_cacache/tmp/git-cloneXXXXXXDFwwTa
npm ERR! npm ERR! command failed
npm ERR! npm ERR! command sh -c husky install
npm ERR!
```

I found a husky issue where people said the problem is fixed in newer versions: https://github.com/typicode/husky/issues/851
