### PR TITLE
docs: add permission instructions for `createComment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ on:
   issues:
     types: [opened]
 
+# see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions:
+  pull-requests: 'write'
+
 jobs:
   comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I have seen many people asking why the `Resource not accessible by integration` error occurred during the **rest.issues.createComment** . I think the attention points for this issue should be reflected in the documentation. (Unfortunately, I also encountered it, and I always thought it was an error in my secret configuration, which wasted a lot of time,It wasn't until I found the answer here and tried that I got the correct workflow running result. https://github.com/actions/github-script/issues/42#issuecomment-1009592629)

