### PR TITLE
feat!: set `runs.using` to node22

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: '20.x'
+        node-version: '22.x'
         cache: npm
 
     - run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`
 runs:
-  using: node20
+  using: node22
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/core": "^5.0.1",
         "@octokit/plugin-request-log": "^4.0.0",
         "@octokit/plugin-retry": "^6.0.1",
-        "@types/node": "^20.9.0"
+        "@types/node": "^22.10.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -35,7 +35,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=20.0.0 <21.0.0"
+        "node": ">=22.0.0 <23.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1672,11 +1672,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "22.10.2",
+      "resolved": "https://artifactory.csq.fr/api/npm/npm/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/semver": {
@@ -7113,9 +7114,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://artifactory.csq.fr/api/npm/npm/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -8652,11 +8654,11 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "22.10.2",
+      "resolved": "https://artifactory.csq.fr/api/npm/npm/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "@types/semver": {
@@ -12542,9 +12544,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://artifactory.csq.fr/api/npm/npm/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "types/async-function.d.ts",
   "private": true,
   "engines": {
-    "node": ">=20.0.0 <21.0.0"
+    "node": ">=22.0.0 <23.0.0"
   },
   "scripts": {
     "build": "npm run build:types && ncc build src/main.ts",
@@ -47,7 +47,7 @@
     "@octokit/core": "^5.0.1",
     "@octokit/plugin-request-log": "^4.0.0",
     "@octokit/plugin-retry": "^6.0.1",
-    "@types/node": "^20.9.0"
+    "@types/node": "^22.10.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",


### PR DESCRIPTION
Hello,

> [!IMPORTANT]
> This PR introduce a breaking change given it change the target node version from `20` to `22`

## Purpose

NodeJS 22 is the LTS from October 2024.

To support new features like `require(esm)` or [ES2024+](https://compat-table.github.io/compat-table/es2016plus/#node22_0) it would be nice if this action runs on node22

<details>
  <summary>NodeJS Releases</summary>

![Capture d’écran 2024-12-17 à 16 09 17](https://github.com/user-attachments/assets/51905ba0-4dc6-4486-9ece-bc9b2021ea1a)
</details>

## Changes

- [x] change `runs.using`  to `node22`
- [x] change `engines.node` to `">=22.0.0 <23.0.0"`
- [x] bump `@types/node` to `"^22.10.2"` 
- [x] update `.github/actions/install-dependencies/action.yml`  to support `node22`
