### PR TITLE
make octokit instance available as octokit on top of github, to make it easier to seamlessly copy examples from GitHub rest api or octokit documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ uses the GitHub API and the workflow run context.
 To use this action, provide an input named `script` that contains the body of an asynchronous JavaScript function call.
 The following arguments will be provided:
 
-- `github` A pre-authenticated
-  [octokit/rest.js](https://octokit.github.io/rest.js) client with pagination plugins
+- `octokit` (and `github`) A pre-authenticated
+  [octokit/rest.js](https://octokit.github.io/rest.js) client _instance_ with pagination plugins
 - `context` An object containing the [context of the workflow
   run](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts)
 - `core` A reference to the [@actions/core](https://github.com/actions/toolkit/tree/main/packages/core) package
@@ -102,14 +102,14 @@ By default, requests made with the `github` instance will not be retried. You ca
     result-encoding: string
     retries: 3
     script: |
-      github.rest.issues.get({
+      octokit.rest.issues.get({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
       })
 ```
 
-In this example, request failures from `github.rest.issues.get()` will be retried up to 3 times.
+In this example, request failures from `octokit.rest.issues.get()` will be retried up to 3 times.
 
 You can also configure which status codes should be exempt from retries via the `retry-exempt-status-codes` option:
 
@@ -121,7 +121,7 @@ You can also configure which status codes should be exempt from retries via the 
     retries: 3
     retry-exempt-status-codes: 400,401
     script: |
-      github.rest.issues.get({
+      octokit.rest.issues.get({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
+            octokit.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.addLabels({
+            octokit.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -209,12 +209,12 @@ jobs:
             // Get a list of all issues created by the PR opener
             // See: https://octokit.github.io/rest.js/#pagination
             const creator = context.payload.sender.login
-            const opts = github.rest.issues.listForRepo.endpoint.merge({
+            const opts = octokit.rest.issues.listForRepo.endpoint.merge({
               ...context.issue,
               creator,
               state: 'all'
             })
-            const issues = await github.paginate(opts)
+            const issues = await octokit.paginate(opts)
 
             for (const issue of issues) {
               if (issue.number === context.issue.number) {
@@ -226,7 +226,7 @@ jobs:
               }
             }
 
-            await github.rest.issues.createComment({
+            await octokit.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -252,7 +252,7 @@ jobs:
         with:
           script: |
             const diff_url = context.payload.pull_request.diff_url
-            const result = await github.request(diff_url)
+            const result = await octokit.request(diff_url)
             console.log(result)
 ```
 
@@ -289,7 +289,7 @@ jobs:
               name: context.repo.repo,
               label: 'wontfix'
             }
-            const result = await github.graphql(query, variables)
+            const result = await octokit.graphql(query, variables)
             console.log(result)
 ```
 
@@ -310,13 +310,13 @@ jobs:
         with:
           script: |
             const script = require('./path/to/script.js')
-            console.log(script({github, context}))
+            console.log(script({octokit, context}))
 ```
 
 And then export a function from your module:
 
 ```javascript
-module.exports = ({github, context}) => {
+module.exports = ({octokit, context}) => {
   return context.payload.client_payload.value
 }
 ```
@@ -350,15 +350,15 @@ jobs:
         with:
           script: |
             const script = require('./path/to/script.js')
-            await script({github, context, core})
+            await script({octokit, context, core})
 ```
 
 And then export an async function from your module:
 
 ```javascript
-module.exports = async ({github, context, core}) => {
+module.exports = async ({octokit, context, core}) => {
   const {SHA} = process.env
-  const commit = await github.rest.repos.getCommit({
+  const commit = await octokit.rest.repos.getCommit({
     owner: context.repo.owner,
     repo: context.repo.repo,
     ref: `${SHA}`
@@ -487,7 +487,7 @@ jobs:
         with:
           github-token: ${{ secrets.MY_PAT }}
           script: |
-            github.rest.issues.addLabels({
+            octokit.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/dist/index.js
+++ b/dist/index.js
@@ -36286,6 +36286,7 @@ async function main() {
         require: wrapRequire,
         __original_require__: require,
         github,
+        octokit: github,
         context: lib_github.context,
         core: core,
         exec: exec,

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -11,6 +11,7 @@ export declare type AsyncFunctionArguments = {
   context: Context
   core: typeof core
   github: InstanceType<typeof GitHub>
+  octokit: InstanceType<typeof GitHub>
   exec: typeof exec
   glob: typeof glob
   io: typeof io

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,7 @@ async function main(): Promise<void> {
       require: wrapRequire,
       __original_require__: __non_webpack_require__,
       github,
+      octokit: github,
       context,
       core,
       exec,

--- a/types/async-function.d.ts
+++ b/types/async-function.d.ts
@@ -9,6 +9,7 @@ export declare type AsyncFunctionArguments = {
     context: Context;
     core: typeof core;
     github: InstanceType<typeof GitHub>;
+    octokit: InstanceType<typeof GitHub>;
     exec: typeof exec;
     glob: typeof glob;
     io: typeof io;


### PR DESCRIPTION
examples on GitHub [api documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-pull-requests-associated-with-a-commit) use octokit as an octokit instance, so does the [octokit documentation](https://octokit.github.io/rest.js/v21/#repos-list-pull-requests-associated-with-commit) itself. its kinda a bummer to always rename when you copy from documentation or from another files.

I understand that octokit was made available over the github keyword, and I dont want to break that, but it won't hurt nobody to expose octokit instance over the octokit keyword as well and it will help people who use documentation a lot


```javascript
// api docs
await octokit.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls', {
  owner: 'OWNER',
  repo: 'REPO',
  commit_sha: 'COMMIT_SHA',
})

// octokit documentation
octokit.rest.repos.listPullRequestsAssociatedWithCommit({
  owner,
  repo,
  commit_sha,
});
```

what do you think? if this is something you are up for adding, let me know and I adjust documentation accordingly 