### PR TITLE
Update usage of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -35,7 +35,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
v3 is deprecated, let's use the latest and greatest!

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/