### PR TITLE
Clear up package name confusion

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
           result-encoding: string
       - run: |
           echo "- Validating relative require output"
-          if [[ "${{steps.relative-require.outputs.result}}" != "github-script" ]]; then
+          if [[ "${{steps.relative-require.outputs.result}}" != "@actions/github-script" ]]; then
             echo $'::error::\u274C' "Expected '$expected', got ${{steps.relative-require.outputs.result}}"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -429,15 +429,15 @@ jobs:
 ### Use scripts with jsDoc support
 
 If you want type support for your scripts, you could use the command below to install the
-`github-script` type declaration.
+`@actions/github-script` type declaration.
 ```sh
-$ npm i -D @types/github-script@github:actions/github-script
+$ npm i -D @actions/github-script@github:actions/github-script
 ```
 
 And then add the `jsDoc` declaration to your script like this:
 ```js
 // @ts-check
-/** @param {import('@types/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 export default async ({ core, context }) => {
   core.debug("Running something at the moment");
   return context.actor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github-script",
+  "name": "@actions/github-script",
   "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-script",
+      "name": "@actions/github-script",
       "version": "7.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-script",
+  "name": "@actions/github-script",
   "description": "A GitHub action for executing a simple script",
   "version": "7.0.1",
   "author": "GitHub",


### PR DESCRIPTION
- #500 
- https://github.com/advisories/GHSA-v9m5-8c6w-p3m5


This repository is *not* the `github-script` package that's been identified as malware and it has never been published to the NPM registry.

Installing this repository as a repository package via NPM warns about this vulnerability due to the `package.json` name `github-script`. To clear up confusion, I've changed this name to `@actions/github-script` which is under our controlled Actions NPM [scope](https://docs.npmjs.com/about-scopes).