### PR TITLE
Update Node.js version support to 24.x

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         cache: npm
 
     - run: npm ci

--- a/.licenses/npm/@types/node.dep.yml
+++ b/.licenses/npm/@types/node.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@types/node"
-version: 20.9.0
+version: 24.1.0
 type: npm
 summary: TypeScript definitions for node
 homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node

--- a/.licenses/npm/undici-types.dep.yml
+++ b/.licenses/npm/undici-types.dep.yml
@@ -1,14 +1,16 @@
 ---
 name: undici-types
-version: 5.26.5
+version: 7.8.0
 type: npm
 summary: A stand-alone types package for Undici
 homepage: https://undici.nodejs.org
 license: mit
 licenses:
-- sources: Auto-generated MIT license text
+- sources: LICENSE
   text: |
     MIT License
+
+    Copyright (c) Matteo Collina and Undici contributors
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@octokit/core": "^5.0.1",
         "@octokit/plugin-request-log": "^4.0.0",
         "@octokit/plugin-retry": "^6.0.1",
-        "@types/node": "^20.9.0"
+        "@types/node": "^24.1.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -35,7 +35,7 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=20.0.0 <21.0.0"
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1672,11 +1672,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/semver": {
@@ -7113,9 +7114,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -8652,11 +8654,11 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
     "@types/semver": {
@@ -12542,9 +12544,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "@actions/github-script",
   "description": "A GitHub action for executing a simple script",
+  "engines": {
+    "node": ">=24"
+  },
   "version": "7.0.1",
   "author": "GitHub",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "types/async-function.d.ts",
-  "private": true,
-  "engines": {
-    "node": ">=20.0.0 <21.0.0"
-  },
   "scripts": {
     "build": "npm run build:types && ncc build src/main.ts",
     "build:types": "tsc src/async-function.ts -t es5 --declaration --allowJs --emitDeclarationOnly --outDir types",
@@ -47,7 +46,7 @@
     "@octokit/core": "^5.0.1",
     "@octokit/plugin-request-log": "^4.0.0",
     "@octokit/plugin-retry": "^6.0.1",
-    "@types/node": "^20.9.0"
+    "@types/node": "^24.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",


### PR DESCRIPTION
Bump Node.js version requirement from 20.x to 24.x in action configuration and package files. Update @types/node and undici-types dependencies to match Node 24 compatibility.