### PR TITLE
feat: add working-directory input to change script execution directory

### DIFF
--- a/__test__/working-directory.test.ts
+++ b/__test__/working-directory.test.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {validateWorkingDirectory} from '../src/working-directory'
+
+describe('validateWorkingDirectory', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'github-script-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true})
+  })
+
+  test('returns resolved path for existing directory', () => {
+    const result = validateWorkingDirectory(tmpDir)
+    expect(result).toBe(tmpDir)
+  })
+
+  test('resolves relative paths', () => {
+    const result = validateWorkingDirectory(tmpDir)
+    expect(path.isAbsolute(result)).toBe(true)
+  })
+
+  test('throws for non-existent directory', () => {
+    const nonExistent = path.join(tmpDir, 'does-not-exist')
+    expect(() => validateWorkingDirectory(nonExistent)).toThrow(
+      /does not exist/
+    )
+    expect(() => validateWorkingDirectory(nonExistent)).toThrow(nonExistent)
+  })
+
+  test('throws for file path instead of directory', () => {
+    const filePath = path.join(tmpDir, 'file.txt')
+    fs.writeFileSync(filePath, 'content')
+    expect(() => validateWorkingDirectory(filePath)).toThrow(
+      /is not a directory/
+    )
+    expect(() => validateWorkingDirectory(filePath)).toThrow(filePath)
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   base-url:
     description: An optional GitHub REST API URL to connect to a different GitHub instance. For example, https://my.github-enterprise-server.com/api/v3
     required: false
+  working-directory:
+    description: The working directory where the script will be executed. If not provided, the current working directory is used.
+    required: false
 outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`

--- a/dist/index.js
+++ b/dist/index.js
@@ -65092,6 +65092,11 @@ async function main() {
     }
     const github = getOctokit(token, opts, retry, requestLog);
     const script = core.getInput('script', { required: true });
+    const workingDirectory = core.getInput('working-directory');
+    if (workingDirectory) {
+        core.info(`Changing working directory to ${workingDirectory}`);
+        process.chdir(workingDirectory);
+    }
     // Wrap getOctokit so secondary clients inherit retry, logging,
     // orchestration ID, and the action's retries input.
     // Deep-copy opts to prevent shared references with the primary client.

--- a/dist/index.js
+++ b/dist/index.js
@@ -65029,6 +65029,27 @@ function parseNumberArray(listString) {
 
 // EXTERNAL MODULE: external "path"
 var external_path_ = __nccwpck_require__(1017);
+;// CONCATENATED MODULE: ./src/working-directory.ts
+
+
+/**
+ * Validates that the given directory exists and is accessible.
+ * @param workingDirectory - The directory path to validate
+ * @returns The resolved absolute path
+ * @throws Error if the directory does not exist or is not a directory
+ */
+function validateWorkingDirectory(workingDirectory) {
+    const resolved = external_path_.resolve(workingDirectory);
+    if (!external_fs_.existsSync(resolved)) {
+        throw new Error(`working-directory "${workingDirectory}" does not exist (resolved to "${resolved}")`);
+    }
+    const stat = external_fs_.statSync(resolved);
+    if (!stat.isDirectory()) {
+        throw new Error(`working-directory "${workingDirectory}" is not a directory (resolved to "${resolved}")`);
+    }
+    return resolved;
+}
+
 ;// CONCATENATED MODULE: ./src/wrap-require.ts
 
 const wrapRequire = new Proxy(require, {
@@ -65053,6 +65074,7 @@ const wrapRequire = new Proxy(require, {
 });
 
 ;// CONCATENATED MODULE: ./src/main.ts
+
 
 
 
@@ -65094,8 +65116,9 @@ async function main() {
     const script = core.getInput('script', { required: true });
     const workingDirectory = core.getInput('working-directory');
     if (workingDirectory) {
-        core.info(`Changing working directory to ${workingDirectory}`);
-        process.chdir(workingDirectory);
+        const resolved = validateWorkingDirectory(workingDirectory);
+        core.info(`Changing working directory to ${resolved}`);
+        process.chdir(resolved);
     }
     // Wrap getOctokit so secondary clients inherit retry, logging,
     // orchestration ID, and the action's retries input.

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,12 @@ async function main(): Promise<void> {
 
   const github = getOctokit(token, opts, retry, requestLog)
   const script = core.getInput('script', {required: true})
+  const workingDirectory = core.getInput('working-directory')
+
+  if (workingDirectory) {
+    core.info(`Changing working directory to ${workingDirectory}`)
+    process.chdir(workingDirectory)
+  }
 
   // Wrap getOctokit so secondary clients inherit retry, logging,
   // orchestration ID, and the action's retries input.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {RequestRequestOptions} from '@octokit/types'
 import {callAsyncFunction} from './async-function'
 import {createConfiguredGetOctokit} from './create-configured-getoctokit'
 import {RetryOptions, getRetryOptions, parseNumberArray} from './retry-options'
+import {validateWorkingDirectory} from './working-directory'
 import {wrapRequire} from './wrap-require'
 
 process.on('unhandledRejection', handleError)
@@ -62,8 +63,9 @@ async function main(): Promise<void> {
   const workingDirectory = core.getInput('working-directory')
 
   if (workingDirectory) {
-    core.info(`Changing working directory to ${workingDirectory}`)
-    process.chdir(workingDirectory)
+    const resolved = validateWorkingDirectory(workingDirectory)
+    core.info(`Changing working directory to ${resolved}`)
+    process.chdir(resolved)
   }
 
   // Wrap getOctokit so secondary clients inherit retry, logging,

--- a/src/working-directory.ts
+++ b/src/working-directory.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Validates that the given directory exists and is accessible.
+ * @param workingDirectory - The directory path to validate
+ * @returns The resolved absolute path
+ * @throws Error if the directory does not exist or is not a directory
+ */
+export function validateWorkingDirectory(workingDirectory: string): string {
+  const resolved = path.resolve(workingDirectory)
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `working-directory "${workingDirectory}" does not exist (resolved to "${resolved}")`
+    )
+  }
+
+  const stat = fs.statSync(resolved)
+  if (!stat.isDirectory()) {
+    throw new Error(
+      `working-directory "${workingDirectory}" is not a directory (resolved to "${resolved}")`
+    )
+  }
+
+  return resolved
+}


### PR DESCRIPTION
Hey! 👋

This PR adds a `working-directory` input to github-script, similar to how `run` steps support `working-directory` in GitHub Actions.

## The Problem

Before this change, if you wanted your script to run in a different directory, you had to manually call `process.chdir()` in your script. This is:
- Inconvenient
- Error-prone
- Inconsistent with how other GitHub Actions work

## The Solution

Now you can simply specify the working directory:

```yaml
- uses: actions/github-script@v9
  with:
    working-directory: ./my-project
    script: |
      const fs = require('fs');
      console.log(fs.readdirSync('.'));
```

## What Changed

- Added `working-directory` input to `action.yml`
- Added `process.chdir()` call in `main.ts` before script execution
- Updated tests to cover the new feature

## Testing

All existing tests pass, and new tests were added for the working-directory feature.

Closes #426