### PR TITLE
docs: fix inaccuracies and add missing required flags in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,26 +15,32 @@ inputs:
   debug:
     description: Whether to tell the GitHub client to log details of its requests. true or false. Default is to run in debug mode when the GitHub Actions step debug logging is turned on.
     default: ${{ runner.debug == '1' }}
+    required: false
   user-agent:
-    description: An optional user-agent string
+    description: An optional user-agent string. If the ACTIONS_ORCHESTRATION_ID environment variable is set, it is automatically appended to the user-agent for request tracing.
     default: actions/github-script
+    required: false
   previews:
     description: A comma-separated list of GraphQL API previews to accept
+    required: false
   result-encoding:
-    description: Either "string" or "json" (default "json")—how the result will be encoded
+    description: How the result will be encoded—either "string" (uses String()) or "json" (uses JSON.stringify)
     default: json
+    required: false
   retries:
     description: The number of times to retry a request
     default: "0"
+    required: false
   retry-exempt-status-codes:
     description: A comma separated list of status codes that will NOT be retried e.g. "400,500". No effect unless `retries` is set
     default: 400,401,403,404,422 # from https://github.com/octokit/plugin-retry.js/blob/9a2443746c350b3beedec35cf26e197ea318a261/src/index.ts#L14
+    required: false
   base-url:
     description: An optional GitHub REST API URL to connect to a different GitHub instance. For example, https://my.github-enterprise-server.com/api/v3
     required: false
 outputs:
   result:
-    description: The return value of the script, stringified with `JSON.stringify`
+    description: The return value of the script, encoded as a string. Encoded with `JSON.stringify` when `result-encoding` is `json` (default), or with `String()` when `result-encoding` is `string`.
 runs:
   using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary
Corrects inaccuracies and fills documentation gaps in `action.yml` to accurately reflect the current implementation in `src/main.ts` and `src/retry-options.ts`. No behavior or code changes are included.

## Changes
- **`result` output description fixed**: Previously stated the result is always "stringified with `JSON.stringify`", which is only true for `result-encoding: json`. When `result-encoding: string`, the output uses `String()`. Description now covers both paths.
- **`result-encoding` description improved**: Removed the redundant `(default "json")` phrase (already declared in the `default:` field) and replaced with the concrete JS functions used for each mode.
- **`user-agent` description updated**: The `ACTIONS_ORCHESTRATION_ID` environment variable is read at runtime in `main.ts` and silently appended to the user-agent string. This behavior was entirely undocumented in `action.yml`.
- **`required: false` added to all implicitly optional inputs**: `debug`, `user-agent`, `previews`, `result-encoding`, `retries`, and `retry-exempt-status-codes` were all optional but lacked the explicit flag. `previews` in particular had neither a `default:` nor `required: false`, making its optionality ambiguous to tooling and readers.

## Motivation
`action.yml` is the primary machine-readable and human-readable contract for this action. Inaccurate descriptions mislead users and tooling (IDE completions, `actionlint`, documentation generators). The `result` output description was factually wrong for the `string` encoding path, and the undocumented `ACTIONS_ORCHESTRATION_ID` behavior was invisible to users trying to understand or debug user-agent strings in audit logs.

## Impact
- **Users**: No behavioral change. All input names, defaults, and output names are unchanged—full backward compatibility is preserved.
- **Tooling**: `actionlint` and schema validators now see explicit `required: false` on all optional inputs, reducing false-positive warnings.
- **Documentation generators**: Output description now accurately describes both encoding modes.

## Testing
`action.yml` is a metadata file with no executable logic. The change was validated by:

1. Confirming each modified field against the corresponding code path in `src/main.ts` (`result-encoding` switch, `getUserAgentWithOrchestrationId`, `core.getInput` calls).
2. Verifying no input names, defaults, or output names were altered.
3. Running `git diff` to confirm the diff is strictly additive to descriptions and `required: false` flags with no structural changes.
